### PR TITLE
Fix latency calculation when using iterations

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -2899,7 +2899,7 @@ void print_report_lat (struct perftest_parameters *user_param)
 		exit(1);
 	}
 
-	cycles_rtt_quotient = cycles_to_units / rtt_factor;
+	cycles_rtt_quotient = cycles_to_units * rtt_factor;
 	if (user_param->r_flag->unsorted) {
 		printf("#, %s\n", units);
 		for (i = 0; i < measure_cnt; ++i)


### PR DESCRIPTION
Commit 744b5a70c006bf9dd165d834cb4d34c5be69ca05 changed the method
used to calculate the latency in print_report_lat. Formerly macro
cycles_to_usec was used, but this was replaced with code that changed
the order of operations from:

(sample / cycles_to_units) / factor
to
sample / (cycles_to_units / factor)

Changing the divide to a multiply in the new code restores the
correct order of operations:
```
    sample            1                 sample
---------------  *  ------  =  ------------------------
cycles_to_units     factor     cycles_to_units * factor
```
sample / (cycles_to_units * factor)