### PR TITLE
Avoid configuring the MRs with 1's

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1280,11 +1280,15 @@ int create_single_mr(struct pingpong_context *ctx, struct perftest_parameters *u
 		ctx->buf[qp_index] = ctx->mr[qp_index]->addr;
 
 
-	/* Initialize buffer with random numbers */
+	/* Initialize buffer with random numbers except in WRITE_LAT test that it 0's */
 	if (!user_param->use_cuda) {
 		srand(time(NULL));
-		for (i = 0; i < ctx->buff_size; i++) {
-			((char*)ctx->buf[qp_index])[i] = (char)rand();
+		if (user_param->verb == WRITE && user_param->tst == LAT) {
+			memset(ctx->buf[qp_index], 0, ctx->buff_size);
+		} else {
+			for (i = 0; i < ctx->buff_size; i++) {
+				((char*)ctx->buf[qp_index])[i] = (char)rand();
+			}
 		}
 	}
 


### PR DESCRIPTION
Avoid setting the value '1' in the MR. If this happens in a write latency
test then the server will send two consecutive packets, regardless of the
client's state. This can cause the application to hang - If the client
reaches the busy-wait loop after the second write then it'll keep waiting
for the value of the first write forever.
to avoid that we set 0's for the MR only for WRITE LAT tests.

Signed-off-by: Ram Amrani <Ram.Amrani@cavium.com>
Signed-off-by: Zohar Ben Aharon <zoharb@mellanox.com>