### PR TITLE
Correct headers to state the GPL/BSD license

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,14 +1,33 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2011.  ALL RIGHTS RESERVED.
-# This software product is a proprietary product of Mellanox Technologies Ltd.
-# (the "Company") and all right, title, and interest and to the software product,
-# including all associated intellectual property rights, are and shall
-# remain exclusively with the Company.
+# Copyright (C) 2001-2011 Mellanox Technologies Ltd.  All rights reserved.
 #
-# This software product is governed by the End User License Agreement
-# provided with the software product.
-# $COPYRIGHT$
-# $HEADER$
+# This software is available to you under a choice of one of two
+# licenses.  You may choose to be licensed under the terms of the GNU
+# General Public License (GPL) Version 2, available from the file
+# COPYING in the main directory of this source tree, or the
+# OpenIB.org BSD license below:
+#
+#     Redistribution and use in source and binary forms, with or
+#     without modification, are permitted provided that the following
+#     conditions are met:
+#
+#      - Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      - Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials
+#        provided with the distribution.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 #
 
 ACLOCAL_AMFLAGS= -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -1,14 +1,34 @@
 #
-# Copyright (C) Mellanox Technologies Ltd. 2001-2011.  ALL RIGHTS RESERVED.
-# This software product is a proprietary product of Mellanox Technologies Ltd.
-# (the "Company") and all right, title, and interest and to the software product,
-# including all associated intellectual property rights, are and shall
-# remain exclusively with the Company.
+# Copyright (C) 2001-2011 Mellanox Technologies Ltd.  All rights reserved.
 #
-# This software product is governed by the End User License Agreement
-# provided with the software product.
-# $COPYRIGHT$
-# $HEADER$
+# This software is available to you under a choice of one of two
+# licenses.  You may choose to be licensed under the terms of the GNU
+# General Public License (GPL) Version 2, available from the file
+# COPYING in the main directory of this source tree, or the
+# OpenIB.org BSD license below:
+#
+#     Redistribution and use in source and binary forms, with or
+#     without modification, are permitted provided that the following
+#     conditions are met:
+#
+#      - Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      - Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials
+#        provided with the distribution.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
 dnl Process this file with autoconf to produce a configure script.
 
 AC_INIT([perftest],[5.6],[linux-rdma@vger.kernel.org])


### PR DESCRIPTION
Zohar Ben Aharon confirmed that Mellanox provides perftest to be under GPL/BSD license including the build system files configure.ac and Makefile.am (see linux-rdma mailing list discussion).

Thus adjust the headers of the build system files to clearly state the GPL/BSD license (instead of claiming them to be proprietary).