### PR TITLE
Use bash for run_perftest_multi_devices

### DIFF
--- a/run_perftest_multi_devices
+++ b/run_perftest_multi_devices
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Script to launch a multi device test on seperate processes.
 
 GET_HELP=0


### PR DESCRIPTION
run_perftest_multi_devices uses bash specific constructs like arrays. Therefore let is use bash instead of sh (which points to dash on Debian).