### PR TITLE
Cuda benchmark fix, user control over cuda device

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -306,6 +306,7 @@ if [test $HAVE_EXP_OOO_ATTR = yes]; then
 fi
 
 CFLAGS="-g -Wall -D_GNU_SOURCE -O3 $CFLAGS"
+LIBS=$LIBS" -lpthread"
 AC_SUBST([LIBUMAD])
 AC_SUBST([LIBMATH])
 AC_CONFIG_FILES([Makefile])

--- a/configure.ac
+++ b/configure.ac
@@ -291,6 +291,20 @@ if [test $HAVE_PACKET_PACING = yes]; then
 	AC_DEFINE([HAVE_PACKET_PACING], [1], [Have PACKET_PACING support])
 fi
 
+AC_TRY_LINK([#include <infiniband/verbs.h>],
+	[int x = IBV_OOO_RW_DATA_PLACEMENT;], [HAVE_OOO_ATTR=yes], [HAVE_OOO_ATTR=no])
+AM_CONDITIONAL([HAVE_OOO_ATTR], [test "x$HAVE_OOO_ATTR" = "xyes"])
+if [test $HAVE_OOO_ATTR = yes]; then
+	AC_DEFINE([HAVE_OOO_ATTR], [1], [Have Out of order data placement support])
+fi
+
+AC_TRY_LINK([#include <infiniband/verbs_exp.h>],
+	[int x = IBV_EXP_OOO_SUPPORT_RW_DATA_PLACEMENT;], [HAVE_EXP_OOO_ATTR=yes], [HAVE_EXP_OOO_ATTR=no])
+AM_CONDITIONAL([HAVE_EXP_OOO_ATTR], [test "x$HAVE_EXP_OOO_ATTR" = "xyes"])
+if [test $HAVE_EXP_OOO_ATTR = yes]; then
+	AC_DEFINE([HAVE_EXP_OOO_ATTR], [1], [Have Experimental Out of order data placement support])
+fi
+
 CFLAGS="-g -Wall -D_GNU_SOURCE -O3 $CFLAGS"
 AC_SUBST([LIBUMAD])
 AC_SUBST([LIBMATH])

--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@
 #
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT([perftest],[5.6],[linux-rdma@vger.kernel.org])
+AC_INIT([perftest],[5.60],[linux-rdma@vger.kernel.org])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-perftest (4.1-1.0) stable; urgency=low
+perftest (4.2-0.0) stable; urgency=low
 
   * Initial release For Ubuntu (Closes: #182805)
 

--- a/perftest.spec
+++ b/perftest.spec
@@ -1,7 +1,7 @@
 Name:           perftest
 Summary:        IB Performance tests
-Version:        4.1
-Release:        1.0
+Version:        4.2
+Release:        0.0
 License:        BSD 3-Clause, GPL v2 or later
 Group:          Productivity/Networking/Diagnostic
 Source:         http://www.openfabrics.org/downloads/%{name}-%{version}.tar.gz

--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -1004,8 +1004,7 @@ int rdma_client_connect(struct pingpong_context *ctx,struct perftest_parameters 
 		user_param->rem_ud_qkey = event->param.ud.qkey;
 
 		ctx->ah[0] = ibv_create_ah(ctx->pd,&event->param.ud.ah_attr);
-
-		if (!ctx->ah) {
+		if (!ctx->ah[0]) {
 			printf(" Unable to create address handler for UD QP\n");
 			return FAILURE;
 		}

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -2759,7 +2759,10 @@ void print_report_bw (struct perftest_parameters *user_param, struct bw_report_d
 	int num_of_qps = user_param->num_of_qps;
 	long format_factor;
 	long num_of_calculated_iters = user_param->iters;
+
 	int free_my_bw_rep = 0;
+	if (user_param->test_method == RUN_INFINITELY)
+		user_param->tcompleted[opt_posted]= get_cycles();
 
 	cycles_t t,opt_delta, peak_up, peak_down,tsize;
 
@@ -2770,8 +2773,8 @@ void print_report_bw (struct perftest_parameters *user_param, struct bw_report_d
 
 	if (user_param->noPeak == OFF) {
 		/* Find the peak bandwidth unless asked not to in command line */
-		for (i = 0; i < user_param->iters * num_of_qps; ++i) {
-			for (j = i; j < user_param->iters * num_of_qps; ++j) {
+		for (i = 0; i < num_of_calculated_iters * num_of_qps; ++i) {
+			for (j = i; j < num_of_calculated_iters * num_of_qps; ++j) {
 				t = (user_param->tcompleted[j] - user_param->tposted[i]) / (j - i + 1);
 				if (t < opt_delta) {
 					opt_delta  = t;
@@ -2791,7 +2794,7 @@ void print_report_bw (struct perftest_parameters *user_param, struct bw_report_d
 	run_inf_bi_factor = (user_param->duplex && user_param->test_method == RUN_INFINITELY) ? (user_param->verb == SEND ? 1 : 2) : 1 ;
 	tsize = run_inf_bi_factor * user_param->size;
 	num_of_calculated_iters *= (user_param->test_type == DURATION) ? 1 : num_of_qps;
-	location_arr = (user_param->noPeak) ? 0 : user_param->iters*num_of_qps - 1;
+	location_arr = (user_param->noPeak) ? 0 : num_of_calculated_iters - 1;
 	/* support in GBS format */
 	format_factor = (user_param->report_fmt == MBS) ? 0x100000 : 125000000;
 
@@ -2816,7 +2819,7 @@ void print_report_bw (struct perftest_parameters *user_param, struct bw_report_d
 	}
 
 	my_bw_rep->size = (unsigned long)user_param->size;
-	my_bw_rep->iters = user_param->iters;
+	my_bw_rep->iters = num_of_calculated_iters;
 	my_bw_rep->bw_peak = (double)peak_up/peak_down;
 	my_bw_rep->bw_avg = bw_avg;
 	my_bw_rep->msgRate_avg = msgRate_avg;

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -497,7 +497,10 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		printf("      Note (1) in Latency under load test SW rate limit is forced\n");
 
 	}
-
+	#if defined HAVE_OOO_ATTR || defined HAVE_EXP_OOO_ATTR
+	printf("      --use_ooo ");
+	printf(" Use out of order data placement\n");
+	#endif
 	putchar('\n');
 }
 /******************************************************************************
@@ -701,6 +704,7 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->flows		= DEF_FLOWS;
 	user_param->flows_burst		= 1;
 	user_param->perform_warm_up	= 0;
+	user_param->use_ooo		= 0;
 }
 
 /******************************************************************************
@@ -1749,6 +1753,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	static int remote_mac_flag = 0;
 	static int reply_every_flag = 0;
 	static int perform_warm_up_flag = 0;
+	static int use_ooo_flag = 0;
 
 	char *server_ip = NULL;
 	char *client_ip = NULL;
@@ -1870,6 +1875,10 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{ .name = "flows_burst",	.has_arg = 1, .flag = &flows_burst_flag, .val = 1},
 			{ .name = "reply_every",	.has_arg = 1, .flag = &reply_every_flag, .val = 1},
 			{ .name = "perform_warm_up",	.has_arg = 0, .flag = &perform_warm_up_flag, .val = 1},
+
+			#if defined HAVE_OOO_ATTR || defined HAVE_EXP_OOO_ATTR
+			{ .name = "use_ooo",		.has_arg = 0, .flag = &use_ooo_flag, .val = 1},
+			#endif
 			{ 0 }
 		};
 		c = getopt_long(argc,argv,"w:y:p:d:i:m:s:n:t:u:S:x:c:q:I:o:M:r:Q:A:l:D:f:B:T:E:J:j:K:k:X:aFegzRvhbNVCHUOZP",long_options,NULL);
@@ -2459,6 +2468,9 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	if (perform_warm_up_flag) {
 		user_param->perform_warm_up = 1;
 	}
+	if (use_ooo_flag)
+		user_param->use_ooo = 1;
+
 	if (optind == argc - 1) {
 		GET_STRING(user_param->servername,strdupa(argv[optind]));
 

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -458,6 +458,8 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		#ifdef HAVE_CUDA
 		printf("      --use_cuda ");
 		printf(" Use CUDA lib for GPU-Direct testing.\n");
+		printf("      --cuda_device ");
+                printf(" The number of cuda device to use\n");
 		#endif
 
 		#ifdef HAVE_VERBS_EXP
@@ -661,6 +663,7 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->is_rate_limit_type  = 0;
 	user_param->output		= -1;
 	user_param->use_cuda		= 0;
+	user_param->cuda_device		= 0;
 	user_param->mmap_file		= NULL;
 	user_param->mmap_offset		= 0;
 	user_param->iters_per_port[0]	= 0;
@@ -1745,6 +1748,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	static int dont_xchg_versions_flag = 0;
 	static int use_exp_flag = 0;
 	static int use_cuda_flag = 0;
+        static int cuda_device_flag = 0;
 	static int mmap_file_flag = 0;
 	static int mmap_offset_flag = 0;
 	static int ipv6_flag = 0;
@@ -1865,6 +1869,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{ .name = "retry_count",	.has_arg = 1, .flag = &retry_count_flag, .val = 1},
 			{ .name = "dont_xchg_versions",	.has_arg = 0, .flag = &dont_xchg_versions_flag, .val = 1},
 			{ .name = "use_cuda",		.has_arg = 0, .flag = &use_cuda_flag, .val = 1},
+                        { .name = "cuda_device",           .has_arg = 0, .flag = &cuda_device_flag, .val = 1},
 			{ .name = "mmap",		.has_arg = 1, .flag = &mmap_file_flag, .val = 1},
 			{ .name = "mmap-offset",	.has_arg = 1, .flag = &mmap_offset_flag, .val = 1},
 			{ .name = "ipv6",		.has_arg = 0, .flag = &ipv6_flag, .val = 1},
@@ -2331,6 +2336,14 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				if (reply_every_flag) {
 					user_param->reply_every = strtol(optarg, NULL, 0);
 					reply_every_flag = 0;
+				}
+                                if (cuda_device_flag) {
+					user_param->cuda_device = strtol(optarg, NULL, 0);
+					if (user_param->cuda_device < 0){
+						fprintf(stderr," Invalid cuda device number");
+						return FAILURE;
+					}
+					user_param->use_cuda = 1;
 				}
 				if(vlan_pcp_flag) {
 					user_param->vlan_pcp = strtol(optarg, NULL, 0);

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1138,7 +1138,12 @@ static void force_dependecies(struct perftest_parameters *user_param)
 
 		if (user_param->duplex && user_param->verb == SEND) {
 			printf(RESULT_LINE);
-			fprintf(stderr," run_infinitely not supported in SEND Bidirectional BW test\n");
+			fprintf(stderr," run_infinitely mode is not supported in SEND Bidirectional BW test\n");
+			exit(1);
+		}
+		if (user_param->rate_limit_type != DISABLE_RATE_LIMIT) {
+			printf(RESULT_LINE);
+			fprintf(stderr," run_infinitely does not support rate limit feature yet\n");
 			exit(1);
 		}
 	}
@@ -1965,7 +1970,6 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				  break;
 			case 'l': user_param->post_list = strtol(optarg, NULL, 0); break;
 			case 'D': user_param->duration = strtol(optarg, NULL, 0);
-				printf("get the pcpc flag %s\n",optarg);
 				  if (user_param->duration <= 0) {
 					  fprintf(stderr," Duration period must be greater than 0\n");
 					  return 1;

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1471,6 +1471,11 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 	} else {
 
 		switch (attr.vendor_part_id) {
+			case 4099  : dev_fname = CONNECTX3; break;
+			case 4100  : dev_fname = CONNECTX3; break;
+			case 4103  : dev_fname = CONNECTX3_PRO; break;
+			case 4104  : dev_fname = CONNECTX3_PRO; break;
+			case 4113  : dev_fname = CONNECTIB; break;
 			case 4115  : dev_fname = CONNECTX4; break;
 			case 4116  : dev_fname = CONNECTX4; break;
 			case 4117  : dev_fname = CONNECTX4LX; break;
@@ -1479,11 +1484,10 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 			case 4120  : dev_fname = CONNECTX5; break;
 			case 4121  : dev_fname = CONNECTX5EX; break;
 			case 4122  : dev_fname = CONNECTX5EX; break;
-			case 4113  : dev_fname = CONNECTIB; break;
-			case 4099  : dev_fname = CONNECTX3; break;
-			case 4100  : dev_fname = CONNECTX3; break;
-			case 4103  : dev_fname = CONNECTX3_PRO; break;
-			case 4104  : dev_fname = CONNECTX3_PRO; break;
+			case 4123  : dev_fname = CONNECTX6; break;
+			case 4124  : dev_fname = CONNECTX6; break;
+			case 41682 : dev_fname = BLUEFIELD; break;
+			case 41683 : dev_fname = BLUEFIELD; break;
 			case 26418 : dev_fname = CONNECTX2; break;
 			case 26428 : dev_fname = CONNECTX2; break;
 			case 26438 : dev_fname = CONNECTX2; break;

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -458,8 +458,8 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		#ifdef HAVE_CUDA
 		printf("      --use_cuda ");
 		printf(" Use CUDA lib for GPU-Direct testing.\n");
-		printf("      --cuda_device ");
-                printf(" The number of cuda device to use\n");
+		printf("      --cuda_device=<value> ");
+                printf(" The ID of cuda device to use\n");
 		#endif
 
 		#ifdef HAVE_VERBS_EXP
@@ -1869,7 +1869,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{ .name = "retry_count",	.has_arg = 1, .flag = &retry_count_flag, .val = 1},
 			{ .name = "dont_xchg_versions",	.has_arg = 0, .flag = &dont_xchg_versions_flag, .val = 1},
 			{ .name = "use_cuda",		.has_arg = 0, .flag = &use_cuda_flag, .val = 1},
-                        { .name = "cuda_device",           .has_arg = 0, .flag = &cuda_device_flag, .val = 1},
+                        { .name = "cuda_device",        .has_arg = 1, .flag = &cuda_device_flag, .val = 1},
 			{ .name = "mmap",		.has_arg = 1, .flag = &mmap_file_flag, .val = 1},
 			{ .name = "mmap-offset",	.has_arg = 1, .flag = &mmap_offset_flag, .val = 1},
 			{ .name = "ipv6",		.has_arg = 0, .flag = &ipv6_flag, .val = 1},

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -443,6 +443,7 @@ struct perftest_parameters {
 	int             		pkey_index;
 	int				raw_qos;
 	int				use_cuda;
+	int				cuda_device;
 	char				*mmap_file;
 	unsigned long			mmap_offset;
 	/* New test params format pilot. will be used in all flags soon,. */

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -167,7 +167,7 @@
 #define MAX_MTU_RAW_ETERNET	(9600)
 #define MIN_FS_PORT		(5000)
 #define MAX_FS_PORT		(65536)
-
+#define VLAN_PCP_VARIOUS        (8)
 
 #define RESULT_LINE "---------------------------------------------------------------------------------------\n"
 
@@ -317,6 +317,29 @@ struct check_alive_data {
 	int to_exit;
 	int is_events;
 };
+
+/* gen_eth_header .
+ * Description :create raw Ethernet header on buffer
+ *
+ * Parameters :
+ *	 	eth_header - Pointer to output
+ *	 	src_mac - source MAC address of the packet
+ *	 	dst_mac - destination MAC address of the packet
+ *	 	eth_type - IP/or size of ptk
+ *
+ *
+struct ETH_header {
+	uint8_t dst_mac[6];
+	uint8_t src_mac[6];
+	uint16_t eth_type;
+}__attribute__((packed));
+
+struct ETH_vlan_header {
+        uint8_t dst_mac[6];
+        uint8_t src_mac[6];
+        uint32_t vlan_header;
+        uint16_t eth_type;
+}__attribute__((packed));*/
 
 struct perftest_parameters {
 
@@ -473,6 +496,10 @@ struct perftest_parameters {
 	uint32_t			reply_every;
 	int				perform_warm_up;
 	int				use_ooo;
+	int                             vlan_en;
+	uint32_t			vlan_pcp;
+	void 				(*print_eth_func)(void*);
+
 };
 
 struct report_options {

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -285,8 +285,9 @@ enum ctx_device {
 	QLOGIC_AH		= 13,
 	CHELSIO_T6		= 14,
 	CONNECTX5		= 15,
-	CONNECTX5EX		= 16
-
+	CONNECTX5EX		= 16,
+	CONNECTX6		= 17,
+	BLUEFIELD		= 18
 };
 
 /* Units for rate limiter */

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -472,6 +472,7 @@ struct perftest_parameters {
 	int				flows_burst;
 	uint32_t			reply_every;
 	int				perform_warm_up;
+	int				use_ooo;
 };
 
 struct report_options {

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -3612,7 +3612,7 @@ int run_iter_bw_infinitely(struct pingpong_context *ctx,struct perftest_paramete
 {
 	uint64_t		totscnt = 0;
 	uint64_t		totccnt = 0;
-	int 			i,j = 0;
+	int 			i = 0;
 	int 			index = 0,ne;
 	int 			err = 0;
 	#ifdef HAVE_VERBS_EXP

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -54,10 +54,7 @@ struct check_alive_data check_alive_data;
 
 /*----------------------------------------------------------------------------*/
 
-static CUdevice cuDevice;
-static CUcontext cuContext;
-
-static int pp_init_gpu(struct pingpong_context *ctx, size_t _size)
+static int pp_init_gpu(struct pingpong_context *ctx,struct perftest_parameters *user_param,  size_t _size)
 {
 	const size_t gpu_page_size = 64*1024;
 	size_t size = (_size + gpu_page_size - 1) & ~(gpu_page_size - 1);
@@ -69,6 +66,7 @@ static int pp_init_gpu(struct pingpong_context *ctx, size_t _size)
 	}
 
 	int deviceCount = 0;
+	int devID = user_param->cuda_device;
 	error = cuDeviceGetCount(&deviceCount);
 	if (error != CUDA_SUCCESS) {
 		printf("cuDeviceGetCount() returned %d\n", error);
@@ -80,28 +78,30 @@ static int pp_init_gpu(struct pingpong_context *ctx, size_t _size)
 		return 1;
 	} else if (deviceCount == 1)
 		printf("There is 1 device supporting CUDA\n");
-	else
-		printf("There are %d devices supporting CUDA, picking first...\n", deviceCount);
-
-	int devID = 0;
+	else if (deviceCount > devID)
+		printf("There are %d devices supporting CUDA, picking %d...\n", deviceCount, devID);
+	else {
+                printf("Error- There are %d devices supporting CUDA, can not pick device %d...\n", deviceCount, devID);
+		return 1;
+	}
 
 	/* pick up device with zero ordinal (default, or devID) */
-	CUCHECK(cuDeviceGet(&cuDevice, devID));
+	CUCHECK(cuDeviceGet(&ctx->cuDevice, devID));
 
 	char name[128];
 	CUCHECK(cuDeviceGetName(name, sizeof(name), devID));
-	printf("[pid = %d, dev = %d] device name = [%s]\n", getpid(), cuDevice, name);
+	printf("[pid = %d, dev = %d] device name = [%s]\n", getpid(), ctx->cuDevice, name);
 	printf("creating CUDA Ctx\n");
 
 	/* Create context */
-	error = cuCtxCreate(&cuContext, CU_CTX_MAP_HOST, cuDevice);
+	error = cuCtxCreate(&ctx->cuContext, CU_CTX_MAP_HOST, ctx->cuDevice);
 	if (error != CUDA_SUCCESS) {
 		printf("cuCtxCreate() error=%d\n", error);
 		return 1;
 	}
 
 	printf("making it the current CUDA Ctx\n");
-	error = cuCtxSetCurrent(cuContext);
+	error = cuCtxSetCurrent(ctx->cuContext);
 	if (error != CUDA_SUCCESS) {
 		printf("cuCtxSetCurrent() error=%d\n", error);
 		return 1;
@@ -131,7 +131,7 @@ static int pp_free_gpu(struct pingpong_context *ctx)
 	d_A = 0;
 
 	printf("destroying current CUDA Ctx\n");
-	CUCHECK(cuCtxDestroy(cuContext));
+	CUCHECK(cuCtxDestroy(ctx->cuContext));
 
 	return ret;
 }
@@ -1165,60 +1165,62 @@ int create_single_mr(struct pingpong_context *ctx, struct perftest_parameters *u
 	#endif
 
 	#ifdef HAVE_CUDA
-	if (user_param->use_cuda) {
+	if (user_param->use_cuda) 
+	{
 		ctx->is_contig_supported = FAILURE;
-		if(pp_init_gpu(ctx, ctx->buff_size)) {
+		if(pp_init_gpu(ctx, user_param , ctx->buff_size)) {
 			fprintf(stderr, "Couldn't allocate work buf.\n");
 			return FAILURE;
 		}
-	}
+	} 
+	else
 	#endif
-
-	if (user_param->mmap_file != NULL) {
-		#if defined(__FreeBSD__)
-		posix_memalign(ctx->buf, user_param->cycle_buffer, ctx->buff_size);
-		#else
-		ctx->buf = memalign(user_param->cycle_buffer, ctx->buff_size);
-		#endif
-		if (pp_init_mmap(ctx, ctx->buff_size, user_param->mmap_file,
-				 user_param->mmap_offset))
-		{
-			fprintf(stderr, "Couldn't allocate work buf.\n");
-			return FAILURE;
-		}
-
-	} else {
-		/* Allocating buffer for data, in case driver not support contig pages. */
-		if (ctx->is_contig_supported == FAILURE) {
+	{
+		if (user_param->mmap_file != NULL) {
 			#if defined(__FreeBSD__)
-			posix_memalign(ctx->buf[qp_index], user_param->cycle_buffer, ctx->buff_size);
+			posix_memalign(ctx->buf, user_param->cycle_buffer, ctx->buff_size);
 			#else
-			if (user_param->use_hugepages) {
-				if (alloc_hugepage_region(ctx) != SUCCESS){
-					fprintf(stderr, "Failed to allocate hugepage region.\n");
-					return FAILURE;
-				}
-				memset(ctx->buf[qp_index], 0, ctx->buff_size);
-			} else if  (ctx->is_contig_supported == FAILURE) {
-				ctx->buf[qp_index] = memalign(user_param->cycle_buffer, ctx->buff_size);
-			}
+			ctx->buf = memalign(user_param->cycle_buffer, ctx->buff_size);
 			#endif
-			if (!ctx->buf[qp_index]) {
+			if (pp_init_mmap(ctx, ctx->buff_size, user_param->mmap_file,
+					 user_param->mmap_offset))
+			{
 				fprintf(stderr, "Couldn't allocate work buf.\n");
 				return FAILURE;
 			}
 
-			memset(ctx->buf[qp_index], 0, ctx->buff_size);
 		} else {
-			ctx->buf[qp_index] = NULL;
-			#ifdef HAVE_VERBS_EXP
-			exp_flags |= IBV_EXP_ACCESS_ALLOCATE_MR;
-			#else
-			flags |= (1 << 5);
-			#endif
+			/* Allocating buffer for data, in case driver not support contig pages. */
+			if (ctx->is_contig_supported == FAILURE) {
+				#if defined(__FreeBSD__)
+				posix_memalign(ctx->buf[qp_index], user_param->cycle_buffer, ctx->buff_size);
+				#else
+				if (user_param->use_hugepages) {
+					if (alloc_hugepage_region(ctx) != SUCCESS){
+						fprintf(stderr, "Failed to allocate hugepage region.\n");
+						return FAILURE;
+					}
+					memset(ctx->buf[qp_index], 0, ctx->buff_size);
+				} else if  (ctx->is_contig_supported == FAILURE) {
+					ctx->buf[qp_index] = memalign(user_param->cycle_buffer, ctx->buff_size);
+				}
+				#endif
+				if (!ctx->buf[qp_index]) {
+					fprintf(stderr, "Couldn't allocate work buf.\n");
+					return FAILURE;
+				}
+
+				memset(ctx->buf[qp_index], 0, ctx->buff_size);
+			} else {
+				ctx->buf[qp_index] = NULL;
+				#ifdef HAVE_VERBS_EXP
+				exp_flags |= IBV_EXP_ACCESS_ALLOCATE_MR;
+				#else
+				flags |= (1 << 5);
+				#endif
+			}
 		}
 	}
-
 	if (user_param->verb == WRITE) {
 		flags |= IBV_ACCESS_REMOTE_WRITE;
 		#ifdef HAVE_VERBS_EXP

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -4914,13 +4914,11 @@ void *handle_signal_print_thread(void *sigmask)
 			printf("Error when try to wait for SIGALRM\n");
 			return FAILURE;
 		}
-		switch(sig_caught)
-		{
-			case SIGALRM:
+		if(sig_caught == SIGALRM)
 				catch_alarm_infintely();
-			default:
-				printf("Unspported signal caught %d, only SIGALRM is supported\n");
-				return FAILURE;
+		else {
+			printf("Unsupported signal caught %d, only signal %d is supported\n", sig_caught, SIGALRM);
+			return FAILURE;
 		}
 	}
 

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -3640,7 +3640,7 @@ int run_iter_bw_infinitely(struct pingpong_context *ctx,struct perftest_paramete
 	}
 
 	pthread_t print_thread;
-	if (!pthread_create(&print_thread, NULL, &handle_signal_print_thread,(void *)&set)){
+	if (pthread_create(&print_thread, NULL, &handle_signal_print_thread,(void *)&set) != 0){
 		printf("Fail to create thread \n");
 		return FAILURE;
 	}

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1171,7 +1171,7 @@ int create_single_mr(struct pingpong_context *ctx, struct perftest_parameters *u
 			fprintf(stderr, "Couldn't allocate work buf.\n");
 			return FAILURE;
 		}
-	} else
+	}
 	#endif
 
 	if (user_param->mmap_file != NULL) {
@@ -1427,6 +1427,8 @@ int ctx_init(struct pingpong_context *ctx, struct perftest_parameters *user_para
 {
 	int i;
 	int num_of_qps = user_param->num_of_qps / 2;
+
+	ctx->is_contig_supported = FAILURE;
 
 	#ifdef HAVE_ACCL_VERBS
 	enum ibv_exp_query_intf_status intf_status;

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -247,10 +247,10 @@ static void get_cpu_stats(struct perftest_parameters *duration_param,int stat_in
 	}
 }
 
+#ifdef HAVE_VERBS_EXP
 static int check_for_contig_pages_support(struct ibv_context *context)
 {
 	int answer;
-	#ifdef HAVE_VERBS_EXP
 	struct ibv_exp_device_attr attr;
 	memset(&attr,0,sizeof attr);
 	if (ibv_exp_query_device(context,&attr)) {
@@ -258,24 +258,9 @@ static int check_for_contig_pages_support(struct ibv_context *context)
 		return FAILURE;
 	}
 	answer = ( attr.exp_device_cap_flags &= IBV_EXP_DEVICE_MR_ALLOCATE) ? SUCCESS : FAILURE;
-	#else
-	struct ibv_device_attr attr;
-
-	if (ibv_query_device(context,&attr)) {
-		fprintf(stderr, "Couldn't get device attributes\n");
-		return FAILURE;
-	}
-
-	/*
-	 * We assume device driver support contig pages by enabling 23 bit in
-	 * device_cap_flag. this is defined as IBV_DEVICE_MR_ALLOCATE.
-	 * Warning: this bit can represent others things in different devices.
-	 */
-	answer = attr.device_cap_flags & (1 << 23) ? SUCCESS : FAILURE;
-	#endif
 	return answer;
 }
-
+#endif
 #ifdef HAVE_XRCD
 /******************************************************************************
  *
@@ -1463,7 +1448,9 @@ int ctx_init(struct pingpong_context *ctx, struct perftest_parameters *user_para
 	}
 	#endif
 
+	#ifdef HAVE_VERBS_EXP
 	ctx->is_contig_supported  = check_for_contig_pages_support(ctx->context);
+	#endif
 
 	if (user_param->use_hugepages)
 		ctx->is_contig_supported = FAILURE;

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1378,6 +1378,7 @@ int verify_params_with_device_context(struct ibv_context *context,
 	return SUCCESS;
 }
 
+#if defined HAVE_OOO_ATTR || defined HAVE_EXP_OOO_ATTR
 static int verify_ooo_settings(struct pingpong_context *ctx,
 			       struct perftest_parameters *user_param)
 {
@@ -1434,7 +1435,7 @@ static int verify_ooo_settings(struct pingpong_context *ctx,
 		return FAILURE;
 	}
 }
-
+#endif
 int ctx_init(struct pingpong_context *ctx, struct perftest_parameters *user_param)
 {
 	int i;

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -733,7 +733,15 @@ void check_alive(int sig);
  *  Will be triggered every 5 sec and measure BW in this time frame.
  *
  */
-void catch_alarm_infintely(int sig) ;
+void catch_alarm_infintely();
+
+/* handle_signal_print_thread
+*
+* Description :
+* 	Handle thread creation for signal catching in run_infinitely mode
+*
+*/
+void *handle_signal_print_thread(void *sig_mask);
 
 /* ctx_modify_dc_qp_to_init.
  *

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -182,6 +182,10 @@ struct pingpong_context {
 	struct ibv_exp_cq_family		*recv_cq_family;
 	struct ibv_exp_qp_burst_family		**qp_burst_family;
 	#endif
+	#ifdef HAVE_CUDA
+	CUdevice 				cuDevice;
+	CUcontext 				cuContext;
+	#endif
 
 };
 

--- a/src/raw_ethernet_resources.h
+++ b/src/raw_ethernet_resources.h
@@ -54,6 +54,7 @@ struct raw_ethernet_info {
 };
 
 
+
 /* gen_eth_header .
  * Description :create raw Ethernet header on buffer
  *
@@ -64,13 +65,22 @@ struct raw_ethernet_info {
  *	 	eth_type - IP/or size of ptk
  *
  */
-
 struct ETH_header {
 	uint8_t dst_mac[6];
 	uint8_t src_mac[6];
 	uint16_t eth_type;
 }__attribute__((packed));
 
+struct ETH_vlan_header {
+        uint8_t dst_mac[6];
+        uint8_t src_mac[6];
+        uint32_t vlan_header;
+        uint16_t eth_type;
+}__attribute__((packed));
+
+#define VLAN_TPID (0x8100)
+#define VLAN_VID (0x001)
+#define VLAN_CFI (0)
 
 #if defined(__FreeBSD__)
 #if BYTE_ORDER == BIG_ENDIAN
@@ -148,7 +158,10 @@ void print_spec(struct ibv_exp_flow_attr* flow_rules,struct perftest_parameters*
 #else
 void print_spec(struct ibv_flow_attr* flow_rules,struct perftest_parameters* user_param);
 #endif
-void print_ethernet_header(struct ETH_header* p_ethernet_header);
+//void print_ethernet_header(struct ETH_header* p_ethernet_header);
+void print_ethernet_header(void* p_ethernet_header);
+//void print_ethernet_vlan_header(struct ETH_vlan_header* p_ethernet_header);
+void print_ethernet_vlan_header(void* p_ethernet_header);
 void print_ip_header(struct IP_V4_header* ip_header);
 void print_udp_header(struct UDP_header* udp_header);
 void print_pkt(void* pkt,struct perftest_parameters *user_param);


### PR DESCRIPTION
- Fixed the missing branch after pp_init_gpu call. I move a section to be encapsulated by {} to avoid future confusion (This results a confusing diff in comparison but this is just a basic encapsulation, and a branch). This fixes gpu-direct benchmark.
- I moved the cuda contexts from being static to the pingpong context, but only if cuda was compiled.
- Added a new parameter for checking which gpu device is being benchmark.