### PR TITLE
Fix rpmlint issues in perftest.spec

### DIFF
--- a/perftest.spec
+++ b/perftest.spec
@@ -3,7 +3,6 @@ Summary:        IB Performance tests
 Version:        4.2
 Release:        0.0
 License:        BSD 3-Clause, GPL v2 or later
-Group:          Productivity/Networking/Diagnostic
 Source:         http://www.openfabrics.org/downloads/%{name}-%{version}.tar.gz
 Url:            http://www.openfabrics.org
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/perftest.spec
+++ b/perftest.spec
@@ -37,17 +37,17 @@ rm -rf ${RPM_BUILD_ROOT}
 - Use autotools for building package.
 * Sun Dec 30 2012 - idos@mellanox.com
 - Added raw_ethernet_bw to install script.
-* Sat Oct 21 2012 - idos@mellanox.com
+* Sun Oct 21 2012 - idos@mellanox.com
 - Removed write_bw_postlist (feature contained in all BW tests)
 * Sat Oct 20 2012 - idos@mellanox.com
 - Version 2.0 is underway
-* Sun May 14 2012 - idos@mellanox.com
+* Mon May 14 2012 - idos@mellanox.com
 - Removed (deprecated) rdma_bw and rdma_lat tests
-* Sun Feb 02 2012 - idos@mellanox.com
+* Thu Feb 02 2012 - idos@mellanox.com
 - Updated to 1.4.0 version (no compability with older version).
-* Sun Feb 02 2012 - idos@mellanox.com
+* Thu Feb 02 2012 - idos@mellanox.com
 - Merge perftest code for Linux & Windows
-* Mon Jan 01 2012 - idos@mellanox.com
+* Sun Jan 01 2012 - idos@mellanox.com
 - Added atomic benchmarks
 * Sat Apr 18 2009 - hal.rosenstock@gmail.com
 - Change executable names for rdma_lat and rdma_bw


### PR DESCRIPTION
Fixes the following set of rpmlint errors (rpmlint run on EL7):

$ rpmlint perftest.spec
perftest.spec:6: W: non-standard-group Productivity/Networking/Diagnostic
perftest.spec: E: specfile-error warning: bogus date in %changelog: Sat Oct 21 2012 - idos@mellanox.com
perftest.spec: E: specfile-error warning: bogus date in %changelog: Sun May 14 2012 - idos@mellanox.com
perftest.spec: E: specfile-error warning: bogus date in %changelog: Sun Feb 02 2012 - idos@mellanox.com
perftest.spec: E: specfile-error warning: bogus date in %changelog: Sun Feb 02 2012 - idos@mellanox.com
perftest.spec: E: specfile-error warning: bogus date in %changelog: Mon Jan 01 2012 - idos@mellanox.com
0 packages and 1 specfiles checked; 5 errors, 1 warnings.
`