### PR TITLE
Set default un-support for contig memory

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1457,11 +1457,9 @@ int ctx_init(struct pingpong_context *ctx, struct perftest_parameters *user_para
 
 	ctx->is_contig_supported = FAILURE;
 	#ifdef HAVE_VERBS_EXP
-	ctx->is_contig_supported  = check_for_contig_pages_support(ctx->context);
+	if (!user_param->use_hugepages)
+		ctx->is_contig_supported  = check_for_contig_pages_support(ctx->context);
 	#endif
-
-	if (user_param->use_hugepages)
-		ctx->is_contig_supported = FAILURE;
 
 	/* Allocating an event channel if requested. */
 	if (user_param->use_event) {

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1455,6 +1455,7 @@ int ctx_init(struct pingpong_context *ctx, struct perftest_parameters *user_para
 	}
 	#endif
 
+	ctx->is_contig_supported = FAILURE;
 	#ifdef HAVE_VERBS_EXP
 	ctx->is_contig_supported  = check_for_contig_pages_support(ctx->context);
 	#endif


### PR DESCRIPTION
By default we will not support this since it is EXP verbs supported

Signed-off-by: Zohar Ben Aharon <zoharb@mellanox.com>