### PR TITLE
Patches related to inline data and byte unit prints

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1487,6 +1487,8 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 		/* Assuming it's Mellanox HCA or unknown.
 		If you want Inline support in other vendor devices, please send patch to gilr@dev.mellanox.co.il
 		*/
+	} else if (attr.vendor_id == 0x8086) {
+		dev_fname = INTEL_ALL;
 	} else {
 
 		switch (attr.vendor_part_id) {

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -432,9 +432,9 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		printf(" Report RX & TX results separately on Bidirectinal BW tests\n");
 
 		printf("      --report_gbits ");
-		printf(" Report Max/Average BW of test in Gbit/sec (instead of MB/sec)\n");
-		printf("        Note: MB=2^20 byte, while Gb=10^9 bits. Use these formulas for conversion:\n");
-		printf("        Factor=10^9/(20^2*8)=119.2; MB=Gb_result * factor; Gb=MB_result / factor\n");
+		printf(" Report Max/Average BW of test in Gbit/sec (instead of MiB/sec)\n");
+		printf("        Note: MiB=2^20 byte, while Gb=10^9 bits. Use these formulas for conversion:\n");
+		printf("        Factor=10^9/(20^2*8)=119.2; MiB=Gb_result * factor; Gb=MB_result / factor\n");
 
 		if (connection_type != RawEth) {
 			printf("      --report-per-port ");
@@ -495,7 +495,7 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		printf(" Set the maximum rate of sent packages. default unit is [Gbps]. use --rate_units to change that.\n");
 
 		printf("      --rate_units=<units>");
-		printf(" [Mgp] Set the units for rate limit to MBps (M), Gbps (g) or pps (p). default is Gbps (g).\n");
+		printf(" [Mgp] Set the units for rate limit to MiBps (M), Gbps (g) or pps (p). default is Gbps (g).\n");
 		printf("        Note (1): pps not supported with HW limit.\n");
 		printf("        Note (2): When using PP rate_units is forced to Kbps.\n");
 

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -287,7 +287,8 @@ enum ctx_device {
 	CONNECTX5		= 15,
 	CONNECTX5EX		= 16,
 	CONNECTX6		= 17,
-	BLUEFIELD		= 18
+	BLUEFIELD		= 18,
+	INTEL_ALL		= 19
 };
 
 /* Units for rate limiter */

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -175,15 +175,15 @@
 #define CYCLES	"cycles"
 #define USEC	"usec"
 /* The format of the results */
-#define RESULT_FMT		" #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]"
+#define RESULT_FMT		" #bytes     #iterations    BW peak[MiB/sec]    BW average[MiB/sec]   MsgRate[Mpps]"
 
-#define RESULT_FMT_PER_PORT	" #bytes     #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]   BW Port1[MB/sec]   MsgRate Port1[Mpps]   BW Port2[MB/sec]   MsgRate Port2[Mpps]"
+#define RESULT_FMT_PER_PORT	" #bytes     #iterations    BW peak[MiB/sec]    BW average[MiB/sec]   MsgRate[Mpps]   BW Port1[MiB/sec]   MsgRate Port1[Mpps]   BW Port2[MiB/sec]   MsgRate Port2[Mpps]"
 
 #define RESULT_FMT_G	" #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]"
 
 #define RESULT_FMT_G_PER_PORT	" #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]   BW Port1[Gb/sec]   MsgRate Port1[Mpps]   BW Port2[Gb/sec]   MsgRate Port2[Mpps]"
 
-#define RESULT_FMT_QOS  " #bytes    #sl      #iterations    BW peak[MB/sec]    BW average[MB/sec]   MsgRate[Mpps]"
+#define RESULT_FMT_QOS  " #bytes    #sl      #iterations    BW peak[MiB/sec]    BW average[MiB/sec]   MsgRate[Mpps]"
 
 #define RESULT_FMT_G_QOS  " #bytes    #sl      #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]"
 
@@ -260,7 +260,7 @@ typedef enum { ITERATIONS , DURATION } TestMethod;
 /* for duration calculation */
 typedef enum { START_STATE, SAMPLE_STATE, STOP_SAMPLE_STATE, END_STATE} DurationStates;
 
-/* Report format (Gbit/s VS MB/s) */
+/* Report format (Gbit/s VS MiB/s) */
 enum ctx_report_fmt { GBS, MBS };
 
 /* Test method */

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1836,6 +1836,9 @@ struct ibv_qp* ctx_exp_qp_create(struct pingpong_context *ctx,
 		printf("  Actual inline-receive(%d) < requested inline-receive(%d)\n",
 				attr.max_inl_recv, user_param->inline_recv_size);
 
+	if (user_param->inline_size > attr.cap.max_inline_data)
+		user_param->inline_size = attr.cap.max_inline_data;
+
 	return qp;
 }
 #endif
@@ -1888,6 +1891,9 @@ struct ibv_qp* ctx_qp_create(struct pingpong_context *ctx,
 	if (errno == ENOMEM)
 		fprintf(stderr, "Requested SQ size might be too big. Try reducing TX depth and/or inline size.\n");
 		fprintf(stderr, "Current TX depth is %d and  inline size is %d .\n", user_param->tx_depth, user_param->inline_size);
+
+	if (user_param->inline_size > attr.cap.max_inline_data)
+		user_param->inline_size = attr.cap.max_inline_data;
 
 	return qp;
 }


### PR DESCRIPTION
perftest: Use the unambiguous byte unit MiB instead of MB
    
perftest: Use no greater than the max supported inline data size
    
perftest: Add Intel devices to the perftest device list
