### PR TITLE
Change size of mtu buffer exchange to prevent overflow

### DIFF
--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -1702,8 +1702,8 @@ void check_sys_data(struct perftest_comm *user_comm, struct perftest_parameters 
  ******************************************************************************/
 int check_mtu(struct ibv_context *context,struct perftest_parameters *user_param, struct perftest_comm *user_comm) {
 	int curr_mtu=0, rem_mtu=0;
-	char cur[2];
-	char rem[2];
+	char cur[sizeof(int)];
+	char rem[sizeof(int)];
 	int size_of_cur;
 	float rem_vers = atof(user_param->rem_version);
 


### PR DESCRIPTION
The Fedora 27 version of perftest causes a crash because it is built with -fstack-protector-strong

$ ib_read_lat -F -a
---------------------------------------------------------------------------------------
Device not recognized to implement inline feature. Disabling it

************************************
* Waiting for client to connect... *
************************************
*** stack smashing detected ***: <unknown> terminated
Aborted (core dumped)

The variable in check_mtu(), size_of_cur = 4 in that version:

Name         : perftest
Version      : 3.0
Release      : 4.fc27
Arch         : x86_64
Size         : 1.3 M
Source       : perftest-3.0-4.fc27.src.rpm

Tracking that older source down and adding 2 bytes to the cur[] rem[] buffers fixes it.  This version doesn't crash, since it uses 2 bytes instead of 4 (because old strverscmp("5.6","5.31")==-1 and new rem_vers >= 5.31 cause a different path).
