### PR TITLE
fix netinet/ip.h includes

### DIFF
--- a/src/raw_ethernet_fs_rate.c
+++ b/src/raw_ethernet_fs_rate.c
@@ -45,7 +45,7 @@
 #include <string.h>
 #include <signal.h>
 #include <getopt.h>
-#include </usr/include/netinet/ip.h>
+#include <netinet/ip.h>
 #include <poll.h>
 #include "perftest_parameters.h"
 #include "perftest_resources.h"

--- a/src/raw_ethernet_resources.c
+++ b/src/raw_ethernet_resources.c
@@ -45,7 +45,7 @@
 #include <signal.h>
 #include <getopt.h>
 #include <unistd.h>
-#include </usr/include/netinet/ip.h>
+#include <netinet/ip.h>
 #include <poll.h>
 #include "perftest_parameters.h"
 #include "perftest_resources.h"

--- a/src/raw_ethernet_resources.h
+++ b/src/raw_ethernet_resources.h
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <signal.h>
 #include <getopt.h>
-#include </usr/include/netinet/ip.h>
+#include <netinet/ip.h>
 #include <poll.h>
 #include "perftest_parameters.h"
 #include "perftest_resources.h"

--- a/src/raw_ethernet_send_burst_lat.c
+++ b/src/raw_ethernet_send_burst_lat.c
@@ -45,7 +45,7 @@
 #include <string.h>
 #include <signal.h>
 #include <getopt.h>
-#include </usr/include/netinet/ip.h>
+#include <netinet/ip.h>
 #include <poll.h>
 #include "perftest_parameters.h"
 #include "perftest_resources.h"

--- a/src/raw_ethernet_send_bw.c
+++ b/src/raw_ethernet_send_bw.c
@@ -45,7 +45,7 @@
 #include <string.h>
 #include <signal.h>
 #include <getopt.h>
-#include </usr/include/netinet/ip.h>
+#include <netinet/ip.h>
 #include <poll.h>
 #include "perftest_parameters.h"
 #include "perftest_resources.h"

--- a/src/raw_ethernet_send_lat.c
+++ b/src/raw_ethernet_send_lat.c
@@ -45,7 +45,7 @@
 #include <string.h>
 #include <signal.h>
 #include <getopt.h>
-#include </usr/include/netinet/ip.h>
+#include <netinet/ip.h>
 #include <poll.h>
 #include "perftest_parameters.h"
 #include "perftest_resources.h"


### PR DESCRIPTION
do not use absolute path of header file in include directives.