### PR TITLE
Use GCC built-in atomic function

### DIFF
--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -356,7 +356,7 @@ struct perftest_parameters {
 	enum ibv_mtu			curr_mtu;
 	uint64_t			size;
 	uint64_t			dct_key;
-	int				iters;
+	volatile int			iters;
 	uint64_t			iters_per_port[2];
 	uint64_t			*port_by_qp;
 	int				tx_depth;

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -3788,7 +3788,11 @@ int run_iter_bw_infinitely(struct pingpong_context *ctx,struct perftest_paramete
 					}
 					wc_id = (user_param->verb_type == ACCL_INTF) ?
 							0 : (int)wc[i].wr_id;
+#ifdef __GNUC__
+					__sync_fetch_and_add(&user_param->iters, user_param->cq_mod);
+#else
 					user_param->iters += user_param->cq_mod;
+#endif
 					totccnt += user_param->cq_mod;
 					ctx->ccnt[wc_id] += user_param->cq_mod;
 				}


### PR DESCRIPTION
Description:
    When testing ib_write_bw with "--run_infinitely", the function
	catch_alarm_infintely in handle_signal_print_thread thread will set
	the iterations to zero. But in aarch64 platform, it is unsafe. The
	working thread will overwrite the 0 to the number loaded previously,
	so the action set to zero doesn't take effect. And we could see that
	sometimes the result is double or even triple of the average/correct
	value. Using the atomic add function instead of the "+" operator will
	get rid of the risk.

Signed-off-by: Bing Zhao <ilovethull@163.com>