### PR TITLE
Added performance counter display

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,8 +34,8 @@ ACLOCAL_AMFLAGS= -I m4
 AUTOMAKE_OPTIONS= subdir-objects
 
 noinst_LIBRARIES = libperftest.a
-libperftest_a_SOURCES = src/get_clock.c src/perftest_communication.c src/perftest_parameters.c src/perftest_resources.c
-noinst_HEADERS = src/get_clock.h src/perftest_communication.h src/perftest_parameters.h src/perftest_resources.h
+libperftest_a_SOURCES = src/get_clock.c src/perftest_communication.c src/perftest_parameters.c src/perftest_resources.c src/perftest_counters.c
+noinst_HEADERS = src/get_clock.h src/perftest_communication.h src/perftest_parameters.h src/perftest_resources.h src/perftest_counters.h
 
 bin_PROGRAMS = ib_send_bw ib_send_lat ib_write_lat ib_write_bw ib_read_lat ib_read_bw ib_atomic_lat ib_atomic_bw
 bin_SCRIPTS = run_perftest_loopback run_perftest_multi_devices

--- a/src/atomic_bw.c
+++ b/src/atomic_bw.c
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
 		user_param.num_of_qps *= 2;
 	}
 
-	ib_dev = ctx_find_dev(user_param.ib_devname);
+	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev)
 		return 7;
 

--- a/src/atomic_lat.c
+++ b/src/atomic_lat.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
 		user_param.num_of_qps *= 2;
 
 	/* Finding the IB device selected (or defalut if no selected). */
-	ib_dev = ctx_find_dev(user_param.ib_devname);
+	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev) {
 		fprintf(stderr," Unable to find the Infiniband/RoCE device\n");
 		return FAILURE;

--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -1217,6 +1217,12 @@ int create_comm_struct(struct perftest_comm *comm,
 		}
 	}
 
+	if ((user_param->counter_ctx) && (counters_open(user_param->counter_ctx,
+		user_param->ib_devname, user_param->ib_port))) {
+		fprintf(stderr," Unable to access performance counters\n");
+		return FAILURE;
+	}
+
 	return SUCCESS;
 }
 

--- a/src/perftest_communication.h
+++ b/src/perftest_communication.h
@@ -103,6 +103,7 @@
 
 struct perftest_comm {
 	struct pingpong_context    *rdma_ctx;
+	struct counter_context     *counter_ctx;
 	struct perftest_parameters *rdma_params;
 };
 

--- a/src/perftest_counters.c
+++ b/src/perftest_counters.c
@@ -1,0 +1,125 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include "perftest_parameters.h"
+
+#define COUNTER_PATH "/sys/class/infiniband/%s/ports/%i/%s"
+#define COUNTER_VALUE_MAX_LEN (21)
+
+typedef unsigned long long counter_t;
+
+struct counter_context {
+	char *counter_list;
+	unsigned num_counters;
+	struct {
+		int fd;
+		char *name;
+		counter_t prev_value;
+		counter_t last_value;
+	} counters[];
+};
+
+
+static int counters_read(struct counter_context *ctx)
+{
+	char read_buf[COUNTER_VALUE_MAX_LEN];
+
+	int i;
+	for (i = 0; i < ctx->num_counters; i++) {
+		int read_fd = ctx->counters[i].fd;
+		if (read(read_fd, &read_buf, COUNTER_VALUE_MAX_LEN) < 0) {
+			return -1;
+		}
+
+		ctx->counters[i].prev_value = ctx->counters[i].last_value;
+		ctx->counters[i].last_value = strtoll(read_buf, NULL, 10);
+		(void) lseek(read_fd, 0, SEEK_SET);
+	}
+
+	return SUCCESS;
+}
+
+int counters_alloc(const char *counter_names,
+		struct counter_context **ctx)
+{
+	/* Count the number of commas and allocate accordingly */
+	unsigned i, num_counters = (unsigned)(strlen(counter_names) > 0);
+	for (i = 0; i < strlen(counter_names); i++) {
+		if (counter_names[i] == ',') {
+			num_counters++;
+		}
+	}
+
+	ALLOCATE(*ctx, struct counter_context, 3 * num_counters + 1);
+	(*ctx)->counter_list = strdup(counter_names);
+	(*ctx)->num_counters = num_counters;
+	return SUCCESS;
+}
+
+int counters_open(struct counter_context *ctx,
+		const char *dev_name, int port)
+{
+	/* Open the sysfs file for each counter */
+	int i;
+	char *given_path, *real_path, *next_counter;
+	for (i = 0, next_counter = strtok(ctx->counter_list, ",");
+		 i < ctx->num_counters;
+		 i++, next_counter = strtok(0, ",")) {
+		if (asprintf(&given_path, COUNTER_PATH, dev_name, port, next_counter) == -1) {
+			goto counter_cleanup;
+		}
+
+		real_path = realpath(given_path, NULL);
+		if (!real_path) {
+			goto counter_cleanup;
+		}
+
+		free(given_path);
+		if (strstr(real_path, COUNTER_PATH) != 0) {
+			free(real_path);
+			goto counter_cleanup;
+		}
+
+		if ((ctx->counters[i].fd = open(real_path, O_RDONLY)) < 0) {
+			free(real_path);
+			goto counter_cleanup;
+		}
+
+		ctx->counters[i].name = next_counter;
+		ctx->counters[i].last_value = 0;
+		free(real_path);
+	}
+
+	return counters_read(ctx);
+
+counter_cleanup:
+	ctx->num_counters = i;
+	counters_close(ctx);
+	return FAILURE;
+}
+
+void counters_print(struct counter_context *ctx)
+{
+	(void) counters_read(ctx);
+
+	int i;
+	for (i = 0; i < ctx->num_counters; i++) {
+		printf("\t%s=%llu\n", ctx->counters[i].name,
+				ctx->counters[i].last_value - ctx->counters[i].prev_value);
+	}
+	printf("\n");
+}
+
+void counters_close(struct counter_context *ctx)
+{
+	int i;
+	for (i = 0; i < ctx->num_counters; i++) {
+		close(ctx->counters[i].fd);
+	}
+
+	free(ctx->counter_list);
+	free(ctx);
+}

--- a/src/perftest_counters.h
+++ b/src/perftest_counters.h
@@ -1,0 +1,28 @@
+#ifndef PERFTEST_COUNTERS_H
+#define PERFTEST_COUNTERS_H
+
+struct counter_context;
+
+/*
+ * Allocate context for performance counters.
+ */
+int counters_alloc(const char *counter_names,
+		struct counter_context **ctx);
+
+/*
+ * Open a handle to the counters (and sample once).
+ */
+int counters_open(struct counter_context *ctx,
+		const char *dev_name, int port);
+
+/*
+ * Sample and output the values to STDOUT.
+ */
+void counters_print(struct counter_context *ctx);
+
+/*
+ * Close the handle to the counters.
+ */
+void counters_close(struct counter_context *ctx);
+
+#endif

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -351,6 +351,9 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		printf(" Set verifier limit for bandwidth\n");
 	}
 
+	printf("  -W, --report-counters=<list of counter names> ");
+	printf(" Report performance counter change (example: \"counters/port_xmit_data,hw_counters/out_of_buffer\")\n");
+
 	if (connection_type != RawEth) {
 		printf("  -x, --gid-index=<index> ");
 		printf(" Test uses GID with GID index (Default : IB - no gid . ETH - 0)\n");
@@ -1902,6 +1905,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{ .name = "client",		.has_arg = 0, .val = 'P' },
 			{ .name = "mac_fwd",		.has_arg = 0, .val = 'v' },
 			{ .name = "use_rss",		.has_arg = 0, .val = 'G' },
+			{ .name = "report-counters",	.has_arg = 1, .val = 'W' },
 			{ .name = "force-link",		.has_arg = 1, .flag = &force_link_flag, .val = 1},
 			{ .name = "remote_mac",		.has_arg = 1, .flag = &remote_mac_flag, .val = 1 },
 			{ .name = "local_mac",		.has_arg = 1, .flag = &local_mac_flag, .val = 1 },
@@ -1969,7 +1973,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			#endif
 			{ 0 }
 		};
-		c = getopt_long(argc,argv,"w:y:p:d:i:m:s:n:t:u:S:x:c:q:I:o:M:r:Q:A:l:D:f:B:T:L:E:J:j:K:k:X:aFegzRvhbNVCHUOZP",long_options,NULL);
+		c = getopt_long(argc,argv,"w:y:p:d:i:m:s:n:t:u:S:x:c:q:I:o:M:r:Q:A:l:D:f:B:T:L:E:J:j:K:k:X:W:aFegzRvhbNVCHUOZP",long_options,NULL);
 
 		if (c == -1)
 			break;
@@ -2190,6 +2194,12 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				  user_param->limit_msgrate = strtof(optarg,NULL);
 				  if (user_param->limit_msgrate < 0) {
 					  fprintf(stderr, " Invalid Minimum msgRate Limit\n");
+					  return FAILURE;
+				  }
+				  break;
+			case 'W':
+				  if (counters_alloc(optarg, &user_param->counter_ctx)) {
+					  fprintf(stderr, "Failed to parse the performance counter list\n");
 					  return FAILURE;
 				  }
 				  break;
@@ -2671,8 +2681,6 @@ int check_link_and_mtu(struct ibv_context *context,struct perftest_parameters *u
 			user_param->size = RAWETH_MIN_MSG_SIZE;
 		}
 	}
-	if (!user_param->ib_devname)
-		GET_STRING(user_param->ib_devname,ibv_get_device_name(context->device))
 
 	if (user_param->pkey_index > 0)
 		user_param->pkey_index = ctx_chk_pkey_index(context, user_param->pkey_index);
@@ -2719,10 +2727,6 @@ int check_link(struct ibv_context *context,struct perftest_parameters *user_para
 		user_param->out_reads = ctx_set_out_reads(context,user_param->out_reads);
 	else
 		user_param->out_reads = 1;
-
-
-	if (!user_param->ib_devname)
-		GET_STRING(user_param->ib_devname,ibv_get_device_name(context->device))
 
 	if (user_param->pkey_index > 0)
 		user_param->pkey_index = ctx_chk_pkey_index(context, user_param->pkey_index);
@@ -3002,6 +3006,9 @@ void print_full_bw_report (struct perftest_parameters *user_param, struct bw_rep
 		fflush(stdout);
 		fprintf(stdout, user_param->cpu_util_data.enable ? REPORT_EXT_CPU_UTIL : REPORT_EXT , calc_cpu_util(user_param));
 	}
+	if (user_param->counter_ctx) {
+		counters_print(user_param->counter_ctx);
+	}
 }
 /******************************************************************************
  *
@@ -3129,6 +3136,10 @@ void print_report_lat (struct perftest_parameters *user_param)
 		printf( user_param->cpu_util_data.enable ? REPORT_EXT_CPU_UTIL : REPORT_EXT , calc_cpu_util(user_param));
 	}
 
+	if (user_param->counter_ctx) {
+		counters_print(user_param->counter_ctx);
+	}
+
 	free(delta);
 }
 
@@ -3158,6 +3169,10 @@ void print_report_lat_duration (struct perftest_parameters *user_param)
 				user_param->iters,
 				latency, tps);
 		printf( user_param->cpu_util_data.enable ? REPORT_EXT_CPU_UTIL : REPORT_EXT , calc_cpu_util(user_param));
+	}
+
+	if (user_param->counter_ctx) {
+		counters_print(user_param->counter_ctx);
 	}
 }
 

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -59,6 +59,7 @@
 #include <malloc.h>
 #endif
 #include "get_clock.h"
+#include "perftest_counters.h"
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>
@@ -510,6 +511,7 @@ struct perftest_parameters {
 	int                             vlan_en;
 	uint32_t			vlan_pcp;
 	void 				(*print_eth_func)(void*);
+	struct counter_context		*counter_ctx;
 
 };
 

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -249,7 +249,8 @@ int check_add_port(char **service,int port,
 /* ctx_find_dev
  *
  * Description : Returns the device corresponding to ib_devname
- *	or the first one found , in case ib_devname == NULL
+ *	or the first one found , in case ib_devname == NULL.
+ *	Also sets the actual device name selected.
  *
  * Parameters :
  *
@@ -257,7 +258,7 @@ int check_add_port(char **service,int port,
  *
  * Return Value : the device or NULL in case of failure.
  */
-struct ibv_device* ctx_find_dev(const char *ib_devname);
+struct ibv_device* ctx_find_dev(char **ib_devname);
 
 /* create_rdma_resources
  *

--- a/src/raw_ethernet_fs_rate.c
+++ b/src/raw_ethernet_fs_rate.c
@@ -93,13 +93,12 @@ int main(int argc, char *argv[])
 	memset(rem_dest_info, 0, sizeof(struct raw_ethernet_info) * user_param.num_of_qps);
 
 	/* Finding the IB device selected (or default if no selected). */
-	ib_dev = ctx_find_dev(user_param.ib_devname);
+	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev) {
 		fprintf(stderr, "Unable to find the Infiniband/RoCE device\n");
 		DEBUG_LOG(TRACE, "<<<<<<%s", __FUNCTION__);
 		return FAILURE;
 	}
-	GET_STRING(user_param.ib_devname, ibv_get_device_name(ib_dev));
 
 	if (check_flow_steering_support(user_param.ib_devname)) {
 		return FAILURE;

--- a/src/raw_ethernet_send_burst_lat.c
+++ b/src/raw_ethernet_send_burst_lat.c
@@ -118,13 +118,12 @@ int main(int argc, char *argv[])
 	user_param.duplex  = 1;
 
 	/* Find the selected IB device (or default if the user didn't select one). */
-	ib_dev = ctx_find_dev(user_param.ib_devname);
+	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev) {
 		fprintf(stderr," Unable to find the Infiniband/RoCE device\n");
 		DEBUG_LOG(TRACE,"<<<<<<%s",__FUNCTION__);
 		return FAILURE;
 	}
-	GET_STRING(user_param.ib_devname, ibv_get_device_name(ib_dev));
 
 	if (check_flow_steering_support(user_param.ib_devname)) {
 		return FAILURE;

--- a/src/raw_ethernet_send_bw.c
+++ b/src/raw_ethernet_send_bw.c
@@ -153,13 +153,12 @@ int main(int argc, char *argv[])
 	}
 
 	/* Finding the IB device selected (or default if no selected). */
-	ib_dev = ctx_find_dev(user_param.ib_devname);
+	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev) {
 		fprintf(stderr," Unable to find the Infiniband/RoCE device\n");
 		DEBUG_LOG(TRACE, "<<<<<<%s", __FUNCTION__);
 		return FAILURE;
 	}
-	GET_STRING(user_param.ib_devname, ibv_get_device_name(ib_dev));
 
 	if (check_flow_steering_support(user_param.ib_devname)) {
 		return FAILURE;

--- a/src/raw_ethernet_send_lat.c
+++ b/src/raw_ethernet_send_lat.c
@@ -118,13 +118,12 @@ int main(int argc, char *argv[])
 	user_param.duplex  = 1;
 
 	/* Find the selected IB device (or default if the user didn't select one). */
-	ib_dev = ctx_find_dev(user_param.ib_devname);
+	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev) {
 		fprintf(stderr," Unable to find the Infiniband/RoCE device\n");
 		DEBUG_LOG(TRACE,"<<<<<<%s",__FUNCTION__);
 		return FAILURE;
 	}
-	GET_STRING(user_param.ib_devname, ibv_get_device_name(ib_dev));
 
 	if (check_flow_steering_support(user_param.ib_devname)) {
 		return FAILURE;

--- a/src/read_bw.c
+++ b/src/read_bw.c
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
 		user_param.num_of_qps *= 2;
 	}
 
-	ib_dev =ctx_find_dev(user_param.ib_devname);
+	ib_dev =ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev)
 		return 7;
 

--- a/src/read_lat.c
+++ b/src/read_lat.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Finding the IB device selected (or defalut if no selected). */
-	ib_dev = ctx_find_dev(user_param.ib_devname);
+	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev) {
 		fprintf(stderr," Unable to find the Infiniband/RoCE device\n");
 		return FAILURE;

--- a/src/send_bw.c
+++ b/src/send_bw.c
@@ -66,6 +66,7 @@ static int set_mcast_group(struct pingpong_context *ctx,
 	mcg_params->sm_lid  = port_attr.sm_lid;
 	mcg_params->sm_sl   = port_attr.sm_sl;
 	mcg_params->ib_port = user_param->ib_port;
+	mcg_params->ib_devname = user_param->ib_devname;
 
 	if (!strcmp(link_layer_str(user_param->link_type),"IB")) {
 		/* Request for Mcast group create registery in SM. */
@@ -191,14 +192,11 @@ int main(int argc, char *argv[])
 	}
 
 	/* Finding the IB device selected (or defalut if no selected). */
-	ib_dev = ctx_find_dev(user_param.ib_devname);
+	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev) {
 		fprintf(stderr," Unable to find the Infiniband/RoCE device\n");
 		return FAILURE;
 	}
-
-	if (user_param.use_mcg)
-		GET_STRING(mcg_params.ib_devname,ibv_get_device_name(ib_dev));
 
 	/* Getting the relevant context from the device */
 	ctx.context = ibv_open_device(ib_dev);

--- a/src/send_lat.c
+++ b/src/send_lat.c
@@ -75,6 +75,7 @@ static int set_mcast_group(struct pingpong_context *ctx,
 	mcg_params->sm_sl   = port_attr.sm_sl;
 	mcg_params->ib_port = user_param->ib_port;
 	mcg_params->user_mgid = user_param->user_mgid;
+	mcg_params->ib_devname = user_param->ib_devname;
 	set_multicast_gid(mcg_params,ctx->qp[0]->qp_num,(int)user_param->machine);
 
 	if (!strcmp(link_layer_str(user_param->link_type),"IB")) {
@@ -222,14 +223,11 @@ int main(int argc, char *argv[])
 	}
 
 	/* Finding the IB device selected (or defalut if no selected). */
-	ib_dev = ctx_find_dev(user_param.ib_devname);
+	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev) {
 		fprintf(stderr," Unable to find the Infiniband/RoCE device\n");
 		return FAILURE;
 	}
-
-	if (user_param.use_mcg)
-		GET_STRING(mcg_params.ib_devname,ibv_get_device_name(ib_dev));
 
 	/* Getting the relevant context from the device */
 	ctx.context = ibv_open_device(ib_dev);

--- a/src/write_bw.c
+++ b/src/write_bw.c
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Finding the IB device selected (or default if none is selected). */
-	ib_dev = ctx_find_dev(user_param.ib_devname);
+	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev) {
 		fprintf(stderr," Unable to find the Infiniband/RoCE device\n");
 		return FAILURE;

--- a/src/write_lat.c
+++ b/src/write_lat.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Finding the IB device selected (or defalut if no selected). */
-	ib_dev = ctx_find_dev(user_param.ib_devname);
+	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev) {
 		fprintf(stderr," Unable to find the Infiniband/RoCE device\n");
 		return FAILURE;


### PR DESCRIPTION
Description:
    Added an optional display of performance counter values -
    based on what is exported in sysfs. The user can request
    any number of counters (by name), and it will be added to
    the output table. The displayed value would be the diff
    from the last sample (unless in "infinite" mode - counters
    are sampled twice: before and after).

Signed-off-by: Alex Margolin <alex.margolin@huawei.com>