### PR TITLE
perftest: add Broadcom's netxtreme pci ids

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1543,6 +1543,29 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 			case 32882 : dev_fname = QLOGIC_AH; break;
 			case 32883 : dev_fname = QLOGIC_AH; break;
 			case 32912 : dev_fname = QLOGIC_AH; break;
+			case 5638  : dev_fname = NETXTREME; break;
+			case 5652  : dev_fname = NETXTREME; break;
+			case 5824  : dev_fname = NETXTREME; break;
+			case 5825  : dev_fname = NETXTREME; break;
+			case 5827  : dev_fname = NETXTREME; break;
+			case 5839  : dev_fname = NETXTREME; break;
+			case 5846  : dev_fname = NETXTREME; break;
+			case 5847  : dev_fname = NETXTREME; break;
+			case 5848  : dev_fname = NETXTREME; break;
+			case 5849  : dev_fname = NETXTREME; break;
+			case 5855  : dev_fname = NETXTREME; break;
+			case 5858  : dev_fname = NETXTREME; break;
+			case 5859  : dev_fname = NETXTREME; break;
+			case 5861  : dev_fname = NETXTREME; break;
+			case 5867  : dev_fname = NETXTREME; break;
+			case 5869  : dev_fname = NETXTREME; break;
+			case 5871  : dev_fname = NETXTREME; break;
+			case 5872  : dev_fname = NETXTREME; break;
+			case 5873  : dev_fname = NETXTREME; break;
+			case 5968  : dev_fname = NETXTREME; break;
+			case 55296 : dev_fname = NETXTREME; break;
+			case 55298 : dev_fname = NETXTREME; break;
+			case 55300 : dev_fname = NETXTREME; break;
 			default	   : dev_fname = UNKNOWN;
 		}
 	}
@@ -1708,6 +1731,8 @@ static void ctx_set_max_inline(struct ibv_context *context,struct perftest_param
 					    ((user_param->connection_type == XRC) ? DEF_INLINE_SEND_XRC : DEF_INLINE_SEND_RC_UC) ; break;
 				default   : user_param->inline_size = 0;
 			}
+			if (current_dev == NETXTREME)
+				user_param->inline_size = 96;
 
 		} else {
 			user_param->inline_size = 0;

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -291,7 +291,8 @@ enum ctx_device {
 	CONNECTX5EX		= 16,
 	CONNECTX6		= 17,
 	BLUEFIELD		= 18,
-	INTEL_ALL		= 19
+	INTEL_ALL		= 19,
+	NETXTREME		= 20
 };
 
 /* Units for rate limiter */


### PR DESCRIPTION
perftest needs to match the vendor id and device
id to set the supported inline size for a given
adapter. Making entries for all the broadcom boards
to allow wqes with inline data.

Signef-off-by: Devesh Sharma <devesh.sharma@broadcom.com>