### PR TITLE
Add EFA and SRD support for ib_send_* tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -59,41 +59,41 @@ LIBMLX5=
 endif
 
 ib_send_bw_SOURCES = src/send_bw.c src/multicast_resources.c src/multicast_resources.h
-ib_send_bw_LDADD = libperftest.a $(LIBUMAD) $(LIBMATH) $(LIBMLX4) $(LIBMLX5)
+ib_send_bw_LDADD = libperftest.a $(LIBUMAD) $(LIBMATH) $(LIBMLX4) $(LIBMLX5) $(LIBEFA)
 
 ib_send_lat_SOURCES = src/send_lat.c src/multicast_resources.c src/multicast_resources.h
-ib_send_lat_LDADD = libperftest.a $(LIBUMAD) $(LIBMATH) $(LIBMLX4) $(LIBMLX5)
+ib_send_lat_LDADD = libperftest.a $(LIBUMAD) $(LIBMATH) $(LIBMLX4) $(LIBMLX5) $(LIBEFA)
 
 ib_write_lat_SOURCES = src/write_lat.c
-ib_write_lat_LDADD = libperftest.a $(LIBMATH)  $(LIBMLX4) $(LIBMLX5)
+ib_write_lat_LDADD = libperftest.a $(LIBMATH)  $(LIBMLX4) $(LIBMLX5) $(LIBEFA)
 
 ib_write_bw_SOURCES = src/write_bw.c
-ib_write_bw_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5)
+ib_write_bw_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5) $(LIBEFA)
 
 ib_read_lat_SOURCES = src/read_lat.c
-ib_read_lat_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5)
+ib_read_lat_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5) $(LIBEFA)
 
 ib_read_bw_SOURCES = src/read_bw.c
-ib_read_bw_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5)
+ib_read_bw_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5) $(LIBEFA)
 
 ib_atomic_lat_SOURCES = src/atomic_lat.c
-ib_atomic_lat_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5)
+ib_atomic_lat_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5) $(LIBEFA)
 
 ib_atomic_bw_SOURCES = src/atomic_bw.c
-ib_atomic_bw_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5)
+ib_atomic_bw_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5) $(LIBEFA)
 
 if HAVE_RAW_ETH
 raw_ethernet_bw_SOURCES = src/raw_ethernet_send_bw.c
-raw_ethernet_bw_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5)
+raw_ethernet_bw_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5) $(LIBEFA)
 
 raw_ethernet_lat_SOURCES = src/raw_ethernet_send_lat.c
-raw_ethernet_lat_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5)
+raw_ethernet_lat_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5) $(LIBEFA)
 
 raw_ethernet_burst_lat_SOURCES = src/raw_ethernet_send_burst_lat.c
-raw_ethernet_burst_lat_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5)
+raw_ethernet_burst_lat_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5) $(LIBEFA)
 
 raw_ethernet_fs_rate_SOURCES = src/raw_ethernet_fs_rate.c
-raw_ethernet_fs_rate_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5)
+raw_ethernet_fs_rate_LDADD = libperftest.a $(LIBMATH) $(LIBMLX4) $(LIBMLX5) $(LIBEFA)
 
 else
 raw_ethernet_bw_SOURCES =

--- a/README
+++ b/README
@@ -130,7 +130,7 @@ Common Options to all tests:
   -R, --rdma_cm				Connect QPs with rdma_cm and run test on those QPs
   -z, --com_rdma_cm			Communicate with rdma_cm module to exchange data - use regular QPs
   -m, --mtu=<mtu>			QP Mtu size (default: active_mtu from ibv_devinfo)
-  -c, --connection=<RC/UC/UD/XRC/DC>	Connection type RC/UC/UD/XRC/DC (default RC).
+  -c, --connection=<type>		Connection type RC/UC/UD/XRC/DC/SRD (default RC).
   -d, --ib-dev=<dev>			Use IB device <dev> (default: first device found)
   -i, --ib-port=<port>			Use network port <port> of IB device (default: 1)
   -s, --size=<size>			Size of message to exchange (default: 1)

--- a/configure.ac
+++ b/configure.ac
@@ -331,6 +331,13 @@ if [test $HAVE_EXP_OOO_ATTR = yes]; then
 	AC_DEFINE([HAVE_EXP_OOO_ATTR], [1], [Have Experimental Out of order data placement support])
 fi
 
+AC_CHECK_LIB([efa], [efadv_create_driver_qp], [HAVE_SRD=yes LIBEFA=-lefa], [HAVE_SRD=no])
+AM_CONDITIONAL([HAVE_SRD], [test "x$HAVE_SRD" = "xyes"])
+if [test $HAVE_SRD = yes] && [test $HAVE_IBV_WR_API = no]; then
+	AC_DEFINE([HAVE_SRD], [1], [Have SRD support])
+	AC_SUBST([LIBEFA])
+fi
+
 CFLAGS="-g -Wall -D_GNU_SOURCE -O3 $CFLAGS"
 LIBS=$LIBS" -lpthread"
 AC_SUBST([LIBUMAD])

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -79,6 +79,7 @@
 #define RawEth  (3)
 #define XRC (4)
 #define DC  (5)
+#define SRD (6)
 
 /* Genral control definitions */
 #define OFF	     (0)
@@ -295,7 +296,8 @@ enum ctx_device {
 	BLUEFIELD		= 20,
 	BLUEFIELD2		= 21,
 	INTEL_ALL		= 22,
-	NETXTREME		= 23
+	NETXTREME		= 23,
+	EFA			= 24,
 };
 
 /* Units for rate limiter */

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -19,11 +19,15 @@
 #include <sys/stat.h>
 #endif
 
-#include "perftest_resources.h"
-#include "raw_ethernet_resources.h"
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
+#ifdef HAVE_SRD
+#include <infiniband/efadv.h>
+#endif
+
+#include "perftest_resources.h"
+#include "raw_ethernet_resources.h"
 
 #ifdef HAVE_VERBS_EXP
 static enum ibv_exp_wr_opcode exp_opcode_verbs_array[] = {IBV_EXP_WR_SEND,IBV_EXP_WR_RDMA_WRITE,IBV_EXP_WR_RDMA_READ};
@@ -972,7 +976,8 @@ void alloc_ctx(struct pingpong_context *ctx,struct perftest_parameters *user_par
 		ALLOCATE(ctx->exp_wr, struct ibv_exp_send_wr, user_param->num_of_qps * user_param->post_list);
 		#endif
 		ALLOCATE(ctx->wr, struct ibv_send_wr, user_param->num_of_qps * user_param->post_list);
-		if ((user_param->verb == SEND && user_param->connection_type == UD ) || user_param->connection_type == DC) {
+		if ((user_param->verb == SEND && user_param->connection_type == UD) ||
+				user_param->connection_type == DC || user_param->connection_type == SRD) {
 			ALLOCATE(ctx->ah, struct ibv_ah*, user_param->num_of_qps);
 		}
 	}
@@ -1047,9 +1052,10 @@ int destroy_ctx(struct pingpong_context *ctx,
 		first = 0;
 	for (i = first; i < user_param->num_of_qps; i++) {
 
-		if (( (user_param->connection_type == DC && !((!(user_param->duplex || user_param->tst == LAT) && (user_param->machine == SERVER) )
-							|| ((user_param->duplex || user_param->tst == LAT) && (i >= num_of_qps)))) ||
-					user_param->connection_type == UD) && (user_param->tst == LAT || user_param->machine == CLIENT || user_param->duplex)) {
+		if (((user_param->connection_type == DC && !((!(user_param->duplex || user_param->tst == LAT) && user_param->machine == SERVER)
+							|| ((user_param->duplex || user_param->tst == LAT) && i >= num_of_qps))) ||
+					user_param->connection_type == UD || user_param->connection_type == SRD) &&
+				(user_param->tst == LAT || user_param->machine == CLIENT || user_param->duplex)) {
 			if (ibv_destroy_ah(ctx->ah[i])) {
 				fprintf(stderr, "Failed to destroy AH\n");
 				test_result = 1;
@@ -2197,6 +2203,9 @@ struct ibv_qp* ctx_qp_create(struct pingpong_context *ctx,
 		#ifdef HAVE_RAW_ETH
 		case RawEth : attr.qp_type = IBV_QPT_RAW_PACKET; break;
 		#endif
+		#ifdef HAVE_SRD
+		case SRD: attr.qp_type = IBV_QPT_DRIVER; break;
+		#endif
 		default:  fprintf(stderr, "Unknown connection type \n");
 			  return NULL;
 	}
@@ -2231,6 +2240,10 @@ struct ibv_qp* ctx_qp_create(struct pingpong_context *ctx,
 		} else {
 			qp = ctx->cm_id->qp;
 		}
+		#endif
+	} else if (user_param->connection_type == SRD) {
+		#ifdef HAVE_SRD
+		qp = efadv_create_driver_qp(ctx->pd, &attr, EFADV_QP_DRIVER_TYPE_SRD);
 		#endif
 	} else {
 		#ifdef HAVE_IBV_WR_API
@@ -2441,7 +2454,7 @@ int ctx_modify_qp_to_init(struct ibv_qp *qp,struct perftest_parameters *user_par
 		exp_flags = init_flag | IBV_EXP_QP_STATE | IBV_EXP_QP_PORT;
 		#endif
 
-	} else if (user_param->connection_type == UD) {
+	} else if (user_param->connection_type == UD || user_param->connection_type == SRD) {
 		attr.qkey = DEFF_QKEY;
 		flags |= IBV_QP_QKEY;
 
@@ -2593,7 +2606,7 @@ static int ctx_modify_qp_to_rtr(struct ibv_qp *qp,
 			attr->ah_attr.grh.hop_limit = 0xFF;
 			attr->ah_attr.grh.traffic_class = user_param->traffic_class;
 		}
-		if (user_param->connection_type != UD) {
+		if (user_param->connection_type != UD && user_param->connection_type != SRD) {
 
 			attr->path_mtu = user_param->curr_mtu;
 			attr->dest_qp_num = dest->qpn;
@@ -2818,7 +2831,7 @@ int ctx_connect(struct pingpong_context *ctx,
 			}
 		}
 
-		if ((user_param->connection_type == UD || user_param->connection_type == DC) &&
+		if ((user_param->connection_type == UD || user_param->connection_type == DC || user_param->connection_type == SRD) &&
 				(user_param->tst == LAT || user_param->machine == CLIENT || user_param->duplex)) {
 
 			#ifdef HAVE_DC
@@ -2828,9 +2841,8 @@ int ctx_connect(struct pingpong_context *ctx,
 			#endif
 				ctx->ah[i] = ibv_create_ah(ctx->pd,&(attr.ah_attr));
 
-
 			if (!ctx->ah[i]) {
-				fprintf(stderr, "Failed to create AH for UD\n");
+				fprintf(stderr, "Failed to create AH\n");
 				return FAILURE;
 			}
 		}
@@ -3304,7 +3316,7 @@ void ctx_set_send_reg_wqes(struct pingpong_context *ctx,
 
 			} else if (user_param->verb == SEND) {
 
-				if (user_param->connection_type == UD) {
+				if (user_param->connection_type == UD || user_param->connection_type == SRD) {
 
 					ctx->wr[i*user_param->post_list + j].wr.ud.ah = ctx->ah[i];
 					if (user_param->work_rdma_cm) {

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -121,7 +121,7 @@
 #define INC(size,cache_line_size) ((size > cache_line_size) ? ((size%cache_line_size == 0) ?  \
 	       (size) : (cache_line_size*(size/cache_line_size+1))) : (cache_line_size))
 
-#define UD_MSG_2_EXP(size) ((log(size))/(log(2)))
+#define MSG_SZ_2_EXP(size) ((log(size)) / (log(2)))
 
 #define MASK_IS_SET(mask, attr)      (((mask)&(attr))!=0)
 

--- a/src/send_bw.c
+++ b/src/send_bw.c
@@ -378,9 +378,10 @@ int main(int argc, char *argv[])
 	}
 
 	if (user_param.test_method == RUN_ALL) {
-
 		if (user_param.connection_type == UD)
-			size_max_pow =  (int)UD_MSG_2_EXP(MTU_SIZE(user_param.curr_mtu)) + 1;
+			size_max_pow = (int)MSG_SZ_2_EXP(MTU_SIZE(user_param.curr_mtu)) + 1;
+		else if (user_param.connection_type == SRD)
+			size_max_pow = (int)MSG_SZ_2_EXP(user_param.size) + 1;
 
 		for (i = 1; i < size_max_pow ; ++i) {
 

--- a/src/send_lat.c
+++ b/src/send_lat.c
@@ -397,9 +397,10 @@ int main(int argc, char *argv[])
 	ctx_set_send_wqes(&ctx,&user_param,rem_dest);
 
 	if (user_param.test_method == RUN_ALL) {
-
 		if (user_param.connection_type == UD)
-			size_max_pow =  (int)UD_MSG_2_EXP(MTU_SIZE(user_param.curr_mtu)) + 1;
+			size_max_pow = (int)MSG_SZ_2_EXP(MTU_SIZE(user_param.curr_mtu)) + 1;
+		else if (user_param.connection_type == SRD)
+			size_max_pow = (int)MSG_SZ_2_EXP(user_param.size) + 1;
 
 		for (i = 1; i < size_max_pow ; ++i) {
 


### PR DESCRIPTION
Add support for Scalable Reliable Datagram (SRD) connection type which runs
over Amazon Elastic Fabric Adapter (EFA).