### PR TITLE
Allow overriding CQ moderation on post list mode

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -2082,8 +2082,8 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 					  return 1;
 				  } break;
 			case 'Q': CHECK_VALUE(user_param->cq_mod,int,MIN_CQ_MOD,MAX_CQ_MOD,"CQ moderation");
-					  user_param->req_cq_mod = 1;
-					  break;
+				  user_param->req_cq_mod = 1;
+				  break;
 			case 'A':
 				  if (user_param->verb != ATOMIC) {
 					  fprintf(stderr," You are not running the atomic_lat/bw test!\n");

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -412,6 +412,7 @@ struct perftest_parameters {
 	int				rx_depth;
 	int				duplex;
 	int				noPeak;
+	int				req_cq_mod;
 	int				cq_mod;
 	int 				spec;
 	int 				dualport;

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -414,7 +414,6 @@ struct perftest_parameters {
 	int				rx_depth;
 	int				duplex;
 	int				noPeak;
-	int				req_cq_mod;
 	int				cq_mod;
 	int				req_cq_mod;
 	int 				spec;

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -3286,7 +3286,7 @@ void ctx_set_send_reg_wqes(struct pingpong_context *ctx,
 
 			if ((j + 1) % user_param->cq_mod == 0) {
 				ctx->wr[i*user_param->post_list + j].send_flags = IBV_SEND_SIGNALED;
-        #ifdef HAVE_IBV_WR_API
+				#ifdef HAVE_IBV_WR_API
 				ctx->qpx[i]->wr_flags = IBV_SEND_SIGNALED;
 				#endif
 			} else {

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -3909,8 +3909,7 @@ int run_iter_bw(struct pingpong_context *ctx,struct perftest_parameters *user_pa
 						ctx->ccnt[wc_id] += user_param->cq_mod;
 						totccnt += user_param->cq_mod;
 						if (user_param->noPeak == OFF) {
-
-							if (totccnt >=  tot_iters - 1)
+							if (totccnt > tot_iters)
 								user_param->tcompleted[user_param->iters*num_of_qps - 1] = get_cycles();
 							else
 								user_param->tcompleted[totccnt-1] = get_cycles();

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -115,11 +115,14 @@
 /* UD addition to the buffer. */
 #define IF_UD_ADD(type,cache_line_size) ((type == UD) ? (cache_line_size) : (0))
 
+#define ROUND_UP(value, alignment) (((value) % (alignment) == 0) ?  \
+		(value) : ((alignment) * ((value) / (alignment) + 1)))
+
 /* Macro that defines the address where we write in RDMA.
  * If message size is smaller then CACHE_LINE size then we write in CACHE_LINE jumps.
  */
-#define INC(size,cache_line_size) ((size > cache_line_size) ? ((size%cache_line_size == 0) ?  \
-	       (size) : (cache_line_size*(size/cache_line_size+1))) : (cache_line_size))
+#define INC(size, cache_line_size) ((size > cache_line_size) ? \
+		ROUND_UP(size, cache_line_size) : (cache_line_size))
 
 #define MSG_SZ_2_EXP(size) ((log(size)) / (log(2)))
 


### PR DESCRIPTION
When posting list of WQEs, allow specifying CQ moderation instead of
overriding it.

For that, request SIGNAL every X WQEs, and fix BW tests to support the
case that cq_mod != post_list.