### PR TITLE
adding ack event for RDMA_CM error event

### DIFF
--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -2321,7 +2321,7 @@ int rdma_cm_connect_events(struct pingpong_context *ctx,
 		rc = rdma_cm_events_dispatcher(ctx, user_param, event->id, event);
 		if (rc) {
 			error_message = "Failed to handle RDMA CM event.";
-			goto error;
+			goto ack;
 		}
 
 		rc = rdma_ack_cm_event(event);
@@ -2332,7 +2332,8 @@ int rdma_cm_connect_events(struct pingpong_context *ctx,
 	}
 
 	return rc;
-
+ack:
+	rdma_ack_cm_event(event);
 error:
 	return error_handler(error_message);
 }
@@ -2374,7 +2375,7 @@ int rdma_cm_disconnect_nodes(struct pingpong_context *ctx,
 		rc = rdma_cm_events_dispatcher(ctx, user_param, event->id, event);
 		if (rc) {
 			error_message = "Failed to handle RDMA CM event.";
-			goto error;
+			goto ack;
 		}
 
 		rc = rdma_ack_cm_event(event);
@@ -2385,7 +2386,8 @@ int rdma_cm_disconnect_nodes(struct pingpong_context *ctx,
 	}
 
 	return rc;
-
+ack:
+	rdma_ack_cm_event(event);
 error:
 	return error_handler(error_message);
 }


### PR DESCRIPTION
RDMA_CM_EVENT_ADDR_ERROR:
RDMA_CM_EVENT_ROUTE_ERROR:
RDMA_CM_EVENT_CONNECT_ERROR:
RDMA_CM_EVENT_UNREACHABLE:
RDMA_CM_EVENT_REJECTED:

without acking such events rdma_destroy_id  will be blocked

Signed-off-by: Leonid Ravich <Leonid.Ravich@emc.com>