### PR TITLE
Add support for HIP/ROCm

### DIFF
--- a/README_ROCm
+++ b/README_ROCm
@@ -1,9 +1,0 @@
-# How to build
-
-$ ./autogen.sh
-$ ./configure --prefix=$PWD/install --enable-rocm --with-rocm=/opt/rocm
-$ make && make install
-
-# How to run
-$ numactl -C 1 ./ib_send_bw -a -F --use_rocm
-$ numactl -C 1 ./ib_send_bw <hostname> -a -F --use_rocm

--- a/README_ROCm
+++ b/README_ROCm
@@ -1,0 +1,9 @@
+# How to build
+
+$ ./autogen.sh
+$ ./configure --prefix=$PWD/install --enable-rocm --with-rocm=/opt/rocm
+$ make && make install
+
+# How to run
+$ numactl -C 1 ./ib_send_bw -a -F --use_rocm
+$ numactl -C 1 ./ib_send_bw <hostname> -a -F --use_rocm

--- a/README_ROCm.md
+++ b/README_ROCm.md
@@ -6,15 +6,25 @@ $ make && make install
 ```
 
 # How to run
+
+## Running Host to Host
 ```
-$ HIP_VISIBLE_DEVICES=0 numactl -C 1 ./ib_send_bw -a -F --use_rocm            #on node 1
-$ HIP_VISIBLE_DEVICES=0 numactl -C 1 ./ib_send_bw <node1> -a -F --use_rocm    #on node 2
+$ numactl -C 1 ./ib_send_bw -a -F            #on node 1
+$ numactl -C 1 ./ib_send_bw <node1> -a -F    #on node 2
+```
+
+## Running GPU#0 to GPU#0
+```
+$ numactl -C 1 ./ib_send_bw -a -F --use_rocm=0            #on node 1
+$ numactl -C 1 ./ib_send_bw <node1> -a -F --use_rocm=0    #on node 2
 ```
 
 # Tips and Tricks
  * Specify a CPU core on the same NUMA node as the HCA
+ * Lock CPU core speed to the highest frequency
  * Try disabling the inline feature (-I 0) for better performance
  * For GPU-GPU transfers, send is usually faster than write
- * By default, GPU#0 is selected. This can be changed by setting
-   `HIP_VISIBLE_DEVICES` or `ROCR_VISIBLE_DEVICES` to the appropriate
-   GPU id.
+ * If `--use_rocm` is specified without any additional parameters,
+   The first visible device (GPU#0) is selected.
+ * Visibility of devices can be controlled by setting the variables
+   `HIP_VISIBLE_DEVICES` or `ROCR_VISIBLE_DEVICES`.

--- a/README_ROCm.md
+++ b/README_ROCm.md
@@ -1,0 +1,20 @@
+# How to build
+```
+$ ./autogen.sh
+$ ./configure --prefix=$PWD/install --enable-rocm --with-rocm=/opt/rocm
+$ make && make install
+```
+
+# How to run
+```
+$ HIP_VISIBLE_DEVICES=0 numactl -C 1 ./ib_send_bw -a -F --use_rocm            #on node 1
+$ HIP_VISIBLE_DEVICES=0 numactl -C 1 ./ib_send_bw <node1> -a -F --use_rocm    #on node 2
+```
+
+# Tips and Tricks
+ * Specify a CPU core on the same NUMA node as the HCA
+ * Try disabling the inline feature (-I 0) for better performance
+ * For GPU-GPU transfers, send is usually faster than write
+ * By default, GPU#0 is selected. This can be changed by setting
+   `HIP_VISIBLE_DEVICES` or `ROCR_VISIBLE_DEVICES` to the appropriate
+   GPU id.

--- a/configure.ac
+++ b/configure.ac
@@ -278,6 +278,34 @@ if [test "$CUDA_H_PATH" ]; then
 	LIBS=$LIBS" -lcuda"
 fi
 
+AC_ARG_ENABLE([rocm],
+              [AS_HELP_STRING([--enable-rocm],
+                              [Enable ROCm benchmarks])
+              ],
+              [],
+              [enable_rocm=no])
+
+AC_ARG_WITH([rocm],
+            [AS_HELP_STRING([--with-rocm=@<:@ROCm installation path@:>@],
+                            [Provide path to ROCm installation])
+            ],
+            [AS_CASE([$with_rocm],
+                     [yes|no], [],
+                     [CPPFLAGS="-I$with_rocm/include $CPPFLAGS"
+                      LDFLAGS="-L$with_rocm/lib64 -Wl,-rpath=$with_rocm/lib64 -L$with_rocm/lib -Wl,-rpath=$with_rocm/lib -lhip_hcc $LDFLAGS"])
+            ])
+
+AS_IF([test "x$enable_rocm" = xyes], [
+       AC_DEFINE([__HIP_PLATFORM_HCC__], [1], [Enable ROCm])
+       AC_CHECK_HEADERS([hip/hip_runtime_api.h], [],
+                        [AC_MSG_ERROR([cannot include hip/hip_runtime_api.h])])
+       AC_SEARCH_LIBS([hipFree], [hip_hcc], [],
+                      [AC_MSG_ERROR([cannot link with -lhip_hcc])])
+       AC_DEFINE([HAVE_ROCM], [1], [Enable ROCm])
+       ])
+
+AM_CONDITIONAL([ROCM], [test x$enable_rocm = xyes])
+
 AC_TRY_LINK([
 #include <infiniband/verbs.h>
 #include <infiniband/verbs_exp.h>],

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -472,6 +472,11 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		printf(" Use CUDA lib for GPU-Direct testing.\n");
 		#endif
 
+		#ifdef HAVE_ROCM
+		printf("      --use_rocm ");
+		printf(" Use ROCM lib for GPU-Direct testing.\n");
+		#endif
+
 		#ifdef HAVE_VERBS_EXP
 		printf("      --use_exp ");
 		printf(" Use Experimental verbs in data path. Default is OFF.\n");
@@ -682,6 +687,7 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->is_rate_limit_type  = 0;
 	user_param->output		= -1;
 	user_param->use_cuda		= 0;
+	user_param->use_rocm		= 0;
 	user_param->mmap_file		= NULL;
 	user_param->mmap_offset		= 0;
 	user_param->iters_per_port[0]	= 0;
@@ -1376,6 +1382,14 @@ static void force_dependecies(struct perftest_parameters *user_param)
 	}
 	#endif
 
+	#ifdef HAVE_ROCM
+	if (user_param->use_rocm && user_param->mmap_file != NULL) {
+		printf(RESULT_LINE);
+		fprintf(stderr,"You cannot use ROCM and an mmap'd file at the same time\n");
+		exit(1);
+	}
+	#endif
+
 	if ( (user_param->connection_type == UD) && (user_param->inline_size > MAX_INLINE_UD) ) {
 		printf(RESULT_LINE);
 		fprintf(stderr, "Setting inline size to %d (Max inline size in UD)\n",MAX_INLINE_UD);
@@ -1838,6 +1852,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	static int dont_xchg_versions_flag = 0;
 	static int use_exp_flag = 0;
 	static int use_cuda_flag = 0;
+	static int use_rocm_flag = 0;
 	static int mmap_file_flag = 0;
 	static int mmap_offset_flag = 0;
 	static int ipv6_flag = 0;
@@ -1961,6 +1976,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{ .name = "retry_count",	.has_arg = 1, .flag = &retry_count_flag, .val = 1},
 			{ .name = "dont_xchg_versions",	.has_arg = 0, .flag = &dont_xchg_versions_flag, .val = 1},
 			{ .name = "use_cuda",		.has_arg = 0, .flag = &use_cuda_flag, .val = 1},
+			{ .name = "use_rocm",		.has_arg = 0, .flag = &use_rocm_flag, .val = 1},
 			{ .name = "mmap",		.has_arg = 1, .flag = &mmap_file_flag, .val = 1},
 			{ .name = "mmap-offset",	.has_arg = 1, .flag = &mmap_offset_flag, .val = 1},
 			{ .name = "ipv6",		.has_arg = 0, .flag = &ipv6_flag, .val = 1},
@@ -2496,6 +2512,11 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	if (use_cuda_flag) {
 		user_param->use_cuda = 1;
 	}
+
+	if (use_rocm_flag) {
+		user_param->use_rocm = 1;
+	}
+
 	if (report_both_flag) {
 		user_param->report_both = 1;
 	}
@@ -2854,6 +2875,10 @@ void ctx_print_test_info(struct perftest_parameters *user_param)
 
 	if (user_param->use_rdma_cm)
 		temp = 1;
+
+#ifdef HAVE_ROCM
+	printf(" Use ROCm memory : %s\n", user_param->use_rocm ? "ON" : "OFF");
+#endif
 
 	printf(" Data ex. method : %s",exchange_state[temp]);
 

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -73,6 +73,10 @@
 #include CUDA_PATH
 #endif
 
+#ifdef HAVE_ROCM
+#include <hip/hip_runtime_api.h>
+#endif
+
 /* Connection types available. */
 #define RC  (0)
 #define UC  (1)
@@ -455,6 +459,7 @@ struct perftest_parameters {
 	int             		pkey_index;
 	int				raw_qos;
 	int				use_cuda;
+	int				use_rocm;
 	char				*mmap_file;
 	unsigned long			mmap_offset;
 	/* New test params format pilot. will be used in all flags soon,. */

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -459,7 +459,7 @@ struct perftest_parameters {
 	int             		pkey_index;
 	int				raw_qos;
 	int				use_cuda;
-	int				use_rocm;
+	int				rocm_dev;
 	char				*mmap_file;
 	unsigned long			mmap_offset;
 	/* New test params format pilot. will be used in all flags soon,. */

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -177,9 +177,13 @@ static int pp_init_gpu(struct pingpong_context *ctx, size_t _size)
     }
 
 	int devID = 0;
+	hipDeviceProp_t prop = {0};
 
 	/* pick up device with zero ordinal (default, or devID) */
 	ROCM_CHECK(hipSetDevice(devID));
+	ROCM_CHECK(hipGetDeviceProperties(&prop, devID));
+	printf("Using HIP Device with Name: %s, PCI Bus ID: 0x%x, GCN Arch: %d\n",
+           prop.name, prop.pciBusID, prop.gcnArch);
 
 	void * d_A;
 	error = hipMalloc(&d_A, size);


### PR DESCRIPTION
Add support for allocating buffers on AMD GPUs through ROCm
Works with Send/Read/Write verbs for Latency and BW tests

To build with ROCm support, use
  ./configure --with-rocm=/path/to/rocm

To run with ROCm enabled, use
  ./ib_write_lat --use_rocm