### PR TITLE
In ctx_alloc_credit function in perftest_resources.c file,

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -3439,7 +3439,7 @@ int ctx_alloc_credit(struct pingpong_context *ctx,
 	int flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE;
 	int i;
 
-	ALLOCATE(ctx->ctrl_buf,uint32_t,user_param->num_of_qps);
+	ALLOCATE(ctx->ctrl_buf,uint32_t,2*user_param->num_of_qps);
 	memset(&ctx->ctrl_buf[0],0,buf_size);
 
 	ctx->credit_buf = (uint32_t *)ctx->ctrl_buf + user_param->num_of_qps;


### PR DESCRIPTION
ctrl_buf is allocated a size of user_param->num_of_qps
however it is being memset to a size of buf_size:

ALLOCATE(ctx->ctrl_buf,uint32_t,user_param->num_of_qps);
memset(&ctx->ctrl_buf[0],0,buf_size);

Fix this by allocating the right size ctrl_buf:

ALLOCATE(ctx->ctrl_buf,uint32_t,buf_size);

Signed-off-by: Sindhu, Devale <sindhu.devale@intel.com>