### PR TITLE
Support post list mode for receive WQEs

### DIFF
--- a/README
+++ b/README
@@ -162,7 +162,8 @@ Options for BW tests:
   -O, --dualport			Run test in dual-port mode (2 QPs). Both ports must be active (default OFF)
   -D, --duration=<sec> 			Run test for <sec> period of seconds
   -f, --margin=<sec> 			When in Duration, measure results within margins (default: 2)
-  -l, --post_list=<list size>		Post list of WQEs of <list size> size (instead of single post)
+  -l, --post_list=<list size>		Post list of send WQEs of <list size> size (instead of single post)
+      --recv_post_list=<list size>	Post list of receive WQEs of <list size> size (instead of single post)
   -q, --qp=<num of qp's>		Num of QPs running in the process (default: 1)
       --run_infinitely			Run test until interrupted by user, print results every 5 seconds
 
@@ -194,15 +195,16 @@ Options for raw_ethernet_send_bw:
 Special feature detailed explanation in tests:
 ----------------------------------------------
 
-  1. Usage of post_list feature (-l, --post_list=<list size>). 
-     In this case, each QP will prepare <list size> ibv_send_wr (instead of 1), and will chain them to each other.
-     In chaining we mean allocating <list_size> array, and setting 'next' pointer of each ibv_send_wr in the array
-     to point to the following element in the array. the last ibv_send_wr in the array will point to NULL.
-     In this case, when post sending the first ibv_send_wr in the list, will instruct the HW to post all of those WQEs.
-     Which means each post_send will post <list_size> messages. 
-     This feature is good we want to know the maximum message rate of QPs in a single process. 
-     Since we are limited to SW post_send (~ 10 Mpps, since we have ~ 500 ns between each SW post_send), we can see 
-     the true HW message rate when setting <list_size> of 64 (for example) since it's not depended on SW limitations. 
+  1. Usage of post_list feature (-l, --post_list=<list size> and --recv_post_list=<list size>)
+     In this case, each QP will prepare <list size> WQEs (instead of 1), and will chain them to each other.
+     In chaining we mean allocating <list_size> array, and setting 'next' pointer of each WQE in the array
+     to point to the following element in the array. the last WQE in the array will point to NULL.
+     In this case, when posting the first WQE in the list, will instruct the HW to post all of those WQEs.
+     Which means each post send/recv will post <list_size> messages.
+     This feature is good if we want to know the maximum message rate of QPs in a single process.
+     Since we are limited to SW posts (for example, on post_send ~ 10 Mpps, since we have ~ 500 ns between
+     each SW post_send), we can see the true HW message rate when setting <list_size> of 64 (for example)
+     since it's not depended on SW limitations.
 
   2. RDMA Connected Mode (CM)
      You can add the "-R" flag to all tests to connect the QPs from each side with the rdma_cm library.

--- a/README
+++ b/README
@@ -241,5 +241,3 @@ Special feature detailed explanation in tests:
 
  7. perftest-2.3 release includes support for dualport VPI test - port1-Ethernet , port2-IB. (in addition to Eth:Eth, IB:IB)
     Currently, running dualport when port1-IB , port2-Ethernet still not working.
-
- 8. for postlist, tests will not finish correctly when using iterations and num_iters/poslist_val has a remainder.

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -254,8 +254,10 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 	}
 
 	if (tst == BW || tst == LAT_BY_BW) {
-		printf("  -l, --post_list=<list size>");
-		printf(" Post list of WQEs of <list size> size (instead of single post)\n");
+		printf("  -l, --post_list=<list size>\n");
+		printf(" Post list of send WQEs of <list size> size (instead of single post)\n");
+		printf("      --recv_post_list=<list size>");
+		printf(" Post list of receive WQEs of <list size> size (instead of single post)\n");
 	}
 
 	if (tst != FS_RATE) {
@@ -641,6 +643,7 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->iters		= (user_param->tst == BW && user_param->verb == WRITE) ? DEF_ITERS_WB : DEF_ITERS;
 	user_param->dualport		= OFF;
 	user_param->post_list		= 1;
+	user_param->recv_post_list	= 1;
 	user_param->use_srq		= OFF;
 	user_param->use_xrc		= OFF;
 	user_param->use_rss		= OFF;
@@ -1021,6 +1024,21 @@ static void force_dependecies(struct perftest_parameters *user_param)
 		{
 			printf(RESULT_LINE);
 			fprintf(stderr, "Post list is supported in BW tests only\n");
+			exit(1);
+		}
+	}
+	if (user_param->recv_post_list > 1) {
+		if (user_param->tst == BW || user_param->tst == LAT_BY_BW) {
+			if (user_param->test_type == ITERATIONS && (user_param->iters % user_param->recv_post_list) != 0) {
+				printf(RESULT_LINE);
+				fprintf(stderr, "Number of iterations must be a multiple of receive post list size\n");
+				exit(1);
+			}
+		}
+		else
+		{
+			printf(RESULT_LINE);
+			fprintf(stderr, "Receive post list is supported in BW tests only\n");
 			exit(1);
 		}
 	}
@@ -1882,6 +1900,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	static int use_ooo_flag = 0;
 	static int vlan_en = 0;
 	static int vlan_pcp_flag = 0;
+	static int recv_post_list_flag = 0;
 
 	char *server_ip = NULL;
 	char *client_ip = NULL;
@@ -2002,6 +2021,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{.name = "perform_warm_up", .has_arg = 0, .flag = &perform_warm_up_flag, .val = 1},
 			{.name = "vlan_en", .has_arg = 0, .flag = &vlan_en, .val = 1},
 			{.name = "vlan_pcp", .has_arg = 1, .flag = &vlan_pcp_flag, .val = 1},
+			{.name = "recv_post_list", .has_arg = 1, .flag = &recv_post_list_flag, .val = 1},
 			#if defined HAVE_RO
 			{.name = "disable_pcie_relaxed", .has_arg = 0, .flag = &disable_pcir_flag, .val = 1 },
 			#endif
@@ -2471,6 +2491,10 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 					}
 					vlan_pcp_flag = 0;
 				}
+				if (recv_post_list_flag) {
+					user_param->recv_post_list = strtol(optarg, NULL, 0);
+					recv_post_list_flag = 0;
+				}
 				break;
 
 			default:
@@ -2843,6 +2867,8 @@ void ctx_print_test_info(struct perftest_parameters *user_param)
 
 	if (user_param->post_list > 1)
 		printf(" Post List       : %d\n",user_param->post_list);
+	if (user_param->recv_post_list > 1)
+		printf(" Recv Post List  : %d\n", user_param->recv_post_list);
 
 	if (user_param->verb == SEND && (user_param->machine == SERVER || user_param->duplex)) {
 		printf(" RX depth        : %d\n",user_param->rx_depth);

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -999,6 +999,11 @@ static void force_dependecies(struct perftest_parameters *user_param)
 	if (user_param->post_list > 1) {
 		if (user_param->tst == BW || user_param->tst == LAT_BY_BW)
 		{
+			if (user_param->test_type == ITERATIONS && (user_param->iters % user_param->post_list) != 0) {
+				printf(RESULT_LINE);
+				fprintf(stderr, "Number of iterations must be a multiple of post list size\n");
+				exit(1);
+			}
 			if (!user_param->req_cq_mod)
 			{
 				user_param->cq_mod = user_param->post_list;

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -413,6 +413,7 @@ struct perftest_parameters {
 	int 				spec;
 	int 				dualport;
 	int 				post_list;
+	int 				recv_post_list;
 	int				duration;
 	int 				use_srq;
 	int				use_xrc;

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -204,6 +204,7 @@ struct pingpong_context {
 	int                                     credit_cnt;
 	int					cache_line_size;
 	int					cycle_buffer;
+	int					rposted;
 	#ifdef HAVE_XRCD
 	struct ibv_xrcd				*xrc_domain;
 	int 					fd;


### PR DESCRIPTION
Similar to TX post list, generate a post list of receive WQEs that are
chained and submitted together.

In order for this work, avoid posting receive WRs immediately after
completion and instead check for available space on QP.

Signed-off-by: Firas Jahjah <firasj@amazon.com>