### PR TITLE
Bug fix - Failed to deallocate PD - Device or resource busy #52

### DIFF
--- a/src/send_bw.c
+++ b/src/send_bw.c
@@ -540,7 +540,7 @@ int main(int argc, char *argv[])
 		fprintf(stderr," Failed to close connection between server and client\n");
 		fprintf(stderr," Trying to close this side resources\n");
 	}
-	user_param.work_rdma_cm = OFF;
+
 	/* Destroy all test resources, including Mcast if exists */
 	if (send_destroy_ctx(&ctx,&user_param,&mcg_params)) {
 		fprintf(stderr,"Couldn't destroy all SEND resources\n");


### PR DESCRIPTION
Root cause - The code calls ibv_dealloc_pd without deregistering
all MR’s associated with that PD. send_destroy_ctx calls destroy_ctx
which doesn’t deregister the credit mr if rdma_cm is OFF.
However, rdma_cm is set to off before calling send_destroy_ctx.

Fix: Remove the line that sets the rdma_cm to OFF.
The code deregisters the MR used for the CM.

Signed-off-by: Yuval Bason <ybason@marvell.com>