### PR TITLE
Falling back to old post_send API for devices not supporting ibv_wr_* one

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,17 +167,19 @@ if [test $HAVE_SNIFFER = yes]; then
         AC_DEFINE([HAVE_SNIFFER], [1], [Enable Sniffer Flow Specification])
 fi
 
-CPU_IS_RO_COMPLIANT=yes
-# Actually this is check for being affected by a known issue
-# with Intel CPUs:
-# https://lore.kernel.org/patchwork/patch/820922/
-intel_no_ro_devices="6f01 6f02 6f03 6f04 6f05 6f06 6f07 6f08 6f09 6f0a 6f0b 6f0c 6f0d 6f0e 2f01 2f02 2f03 2f04 2f05 2f06 2f07 2f08 2f09 2f0a 2f0b 2f0c 2f0d 2f0e"
-for cpu_num in $intel_no_ro_devices; do
-	ro_nonsupported=$(lspci -nn | grep -i 8086:$cpu_num)
-	if [ test "$ro_nonsupported" ]; then
-		CPU_IS_RO_COMPLIANT=no
-	fi
-done
+if [test $IS_FREEBSD = no]; then
+	CPU_IS_RO_COMPLIANT=yes
+	# Actually this is check for being affected by a known issue
+	# with Intel CPUs:
+	# https://lore.kernel.org/patchwork/patch/820922/
+	intel_no_ro_devices="6f01 6f02 6f03 6f04 6f05 6f06 6f07 6f08 6f09 6f0a 6f0b 6f0c 6f0d 6f0e 2f01 2f02 2f03 2f04 2f05 2f06 2f07 2f08 2f09 2f0a 2f0b 2f0c 2f0d 2f0e"
+	for cpu_num in $intel_no_ro_devices; do
+		ro_nonsupported=$(lspci -nn | grep -i 8086:$cpu_num)
+		if [ test "$ro_nonsupported" ]; then
+			CPU_IS_RO_COMPLIANT=no
+		fi
+	done
+fi
 
 AC_TRY_LINK([
 #include <infiniband/verbs.h>],

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1394,12 +1394,25 @@ int verify_params_with_device_context(struct ibv_context *context,
 		}
 	}
 
-	if (current_dev == CONNECTX3_PRO || current_dev == CONNECTX3)
+	// those are devices supporting new post send
+	if (current_dev != CONNECTIB &&
+		current_dev != CONNECTX4 &&
+		current_dev != CONNECTX4LX &&
+		current_dev != CONNECTX5 &&
+		current_dev != CONNECTX5EX &&
+		current_dev != CONNECTX6 &&
+		current_dev != CONNECTX6DX &&
+		current_dev != CONNECTX6LX &&
+		current_dev != CONNECTX7 &&
+		current_dev != MLX5GENVF &&
+		current_dev != BLUEFIELD &&
+		current_dev != BLUEFIELD2 &&
+		current_dev != EFA)
 	{
 		if (!user_param->use_old_post_send)
 		{
-			fprintf(stderr, " Warning: ConnectX-3 and ConnectX-3 Pro don't support WR postsend API!\n");
-			fprintf(stderr, " Warning: Falling back to ibv_post_send() API\n");
+			fprintf(stderr, " Warning: The device chosen doesn't support WR post send API!\n");
+			fprintf(stderr, " Warning: Falling back to using ibv_post_send()\n");
 			user_param->use_old_post_send = 1;
 		}
 	}


### PR DESCRIPTION
Only devices supporting ibv_wr_* API are in the whitelist to use it. Others fall back to old one without issues on QP creation.