### PR TITLE
configure: fix ibv_wr_api enable argument

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,11 +43,10 @@ AC_ARG_VAR(CUDA_H_PATH, help-string)
 AC_ARG_VAR(RANLIB, ranlib tool)
 
 AC_ARG_ENABLE([ibv_wr_api],
-[AS_HELP_STRING([--disable-ibv_wr_api],
-[Disable new post send API])],
-[disable_ibv_wr_api=yes], [disable_ibv_wr_api=no])
+	[AS_HELP_STRING([--disable-ibv_wr_api],
+	[Disable new post send API])])
 
-AS_IF([test "x$disable_ibv_wr_api" = "xyes"],
+AS_IF([test "x$enable_ibv_wr_api" = "xno"],
       [USE_IBV_WR_API=no],
         [USE_IBV_WR_API=yes])
 


### PR DESCRIPTION
The syntax for AC_ARG_ENABLE is:
  AC_ARG_ENABLE(option-name, help-string, action-if-present, action-if-not-present)

The mistake here is to consider the two actions as action-if-enabled and
action-if-disabled.

Scenario:
  ./configure --enable-ibv_wr_api
would end up running action-if-present and cause the new API to be
disabled.

Fix:
Since the default for autoconf when no action is defined is to set a
special variable named with the enable_ prefix, remove the custom
actions and let autoconf handle it.

Fixes: 705ed2e ("Made ibv_wr_api default during the build")
Signed-off-by: Firas Jahjah <firasj@amazon.com>