### PR TITLE
Add support for AMD ROCm GPUs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -195,6 +195,34 @@ if [test $HAVE_EX = yes]; then
 	AC_DEFINE([HAVE_EX], [1], [Have EX support])
 fi
 
+AC_ARG_ENABLE([rocm],
+              [AS_HELP_STRING([--enable-rocm],
+                              [Enable ROCm benchmarks])
+              ],
+              [],
+              [enable_rocm=no])
+
+AC_ARG_WITH([rocm],
+            [AS_HELP_STRING([--with-rocm=@<:@ROCm installation path@:>@],
+                            [Provide path to ROCm installation])
+            ],
+            [AS_CASE([$with_rocm],
+                     [yes|no], [],
+                     [CPPFLAGS="-I$with_rocm/include $CPPFLAGS"
+                      LDFLAGS="-L$with_rocm/lib64 -Wl,-rpath=$with_rocm/lib64 -L$with_rocm/lib -Wl,-rpath=$with_rocm/lib -lamdhip64 $LDFLAGS"])
+            ])
+
+AS_IF([test "x$enable_rocm" = xyes], [
+       AC_DEFINE([__HIP_PLATFORM_HCC__], [1], [Enable ROCm])
+       AC_CHECK_HEADERS([hip/hip_runtime_api.h], [],
+                        [AC_MSG_ERROR([cannot include hip/hip_runtime_api.h])])
+       AC_SEARCH_LIBS([hipFree], [amdhip64], [],
+                      [AC_MSG_ERROR([cannot link with -lamdhip64])])
+       AC_DEFINE([HAVE_ROCM], [1], [Enable ROCm])
+       ])
+
+AM_CONDITIONAL([ROCM], [test x$enable_rocm = xyes])
+
 AC_TRY_LINK([
 #include <infiniband/verbs.h>],
         [int x = IBV_ACCESS_ON_DEMAND;],[HAVE_EX_ODP=yes], [HAVE_EX_ODP=no])

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -477,6 +477,11 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		printf(" Use CUDA specific device for GPUDirect RDMA testing\n");
 		#endif
 
+		#ifdef HAVE_ROCM
+		printf("      --use_rocm=<rocm device id>");
+		printf(" Use selected ROCm device for GPUDirect RDMA testing\n");
+		#endif
+
 		printf("      --use_hugepages ");
 		printf(" Use Hugepages instead of contig, memalign allocations.\n");
 	}
@@ -677,6 +682,10 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 #ifdef HAVE_CUDA
 	user_param->use_cuda		= 0;
 	user_param->cuda_device_id		= 0;
+#endif
+#ifdef HAVE_ROCM
+	user_param->use_rocm		= 0;
+	user_param->rocm_device_id	= 0;
 #endif
 	user_param->mmap_file		= NULL;
 	user_param->mmap_offset		= 0;
@@ -1450,6 +1459,14 @@ static void force_dependecies(struct perftest_parameters *user_param)
 	}
 	#endif
 
+	#ifdef HAVE_ROCM
+	if (user_param->use_rocm && user_param->mmap_file != NULL) {
+		printf(RESULT_LINE);
+		fprintf(stderr,"You cannot use ROCM and an mmap'd file at the same time\n");
+		exit(1);
+	}
+	#endif
+
 	if ( (user_param->connection_type == UD) && (user_param->inline_size > MAX_INLINE_UD) ) {
 		printf(RESULT_LINE);
 		fprintf(stderr, "Setting inline size to %d (Max inline size in UD)\n",MAX_INLINE_UD);
@@ -1869,6 +1886,9 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 #ifdef HAVE_CUDA
 	static int use_cuda_flag = 0;
 #endif
+#ifdef HAVE_ROCM
+	static int use_rocm_flag = 0;
+#endif
 	static int disable_pcir_flag = 0;
 	static int mmap_file_flag = 0;
 	static int mmap_offset_flag = 0;
@@ -1994,6 +2014,9 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{ .name = "dont_xchg_versions",	.has_arg = 0, .flag = &dont_xchg_versions_flag, .val = 1},
 			#ifdef HAVE_CUDA
 			{ .name = "use_cuda",		.has_arg = 1, .flag = &use_cuda_flag, .val = 1},
+			#endif
+			#ifdef HAVE_ROCM
+			{ .name = "use_rocm",		.has_arg = 1, .flag = &use_rocm_flag, .val = 1},
 			#endif
 			{ .name = "mmap",		.has_arg = 1, .flag = &mmap_file_flag, .val = 1},
 			{ .name = "mmap-offset",	.has_arg = 1, .flag = &mmap_offset_flag, .val = 1},
@@ -2369,6 +2392,18 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 						return FAILURE;
 					}
 					use_cuda_flag = 0;
+				}
+#endif
+#ifdef HAVE_ROCM
+				if (use_rocm_flag) {
+					user_param->use_rocm = 1;
+					user_param->rocm_device_id = strtol(optarg, NULL, 0);
+					if (user_param->rocm_device_id < 0)
+					{
+						fprintf(stderr, "Invalid ROCm device %d\n", user_param->rocm_device_id);
+						return FAILURE;
+					}
+					use_rocm_flag = 0;
 				}
 #endif
 				if (flow_label_flag) {
@@ -2900,6 +2935,10 @@ void ctx_print_test_info(struct perftest_parameters *user_param)
 
 	if (user_param->use_rdma_cm)
 		temp = 1;
+
+#ifdef HAVE_ROCM
+	printf(" Use ROCm memory : %s\n", user_param->use_rocm ? "ON" : "OFF");
+#endif
 
 	printf(" Data ex. method : %s",exchange_state[temp]);
 

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -70,6 +70,10 @@
 #include CUDA_PATH
 #endif
 
+#ifdef HAVE_ROCM
+#include <hip/hip_runtime_api.h>
+#endif
+
 /* Connection types available. */
 #define RC  (0)
 #define UC  (1)
@@ -455,6 +459,10 @@ struct perftest_parameters {
 #ifdef HAVE_CUDA
 	int				use_cuda;
 	int				cuda_device_id;
+#endif
+#ifdef HAVE_ROCM
+	int				use_rocm;
+	int				rocm_device_id;
 #endif
 	char				*mmap_file;
 	unsigned long			mmap_offset;

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -131,6 +131,53 @@ static void pp_free_gpu(struct pingpong_context *ctx)
 }
 #endif
 
+#ifdef HAVE_ROCM
+#define ASSERT(x)										\
+	do {											\
+	if (!(x)) {										\
+		fprintf(stdout, "Assertion \"%s\" failed at %s:%d\n", #x, __FILE__, __LINE__);	\
+	}											\
+} while (0)
+
+#define ROCM_CHECK(stmt)			\
+	do {					\
+	hipError_t result = (stmt);		\
+	ASSERT(hipSuccess == result);		\
+} while (0)
+
+/*----------------------------------------------------------------------------*/
+
+static int pp_init_rocm(struct pingpong_context *ctx, int rocm_device_id)
+{
+	int deviceCount = 0;
+	hipError_t error = hipGetDeviceCount(&deviceCount);
+	if (error != hipSuccess) {
+		printf("hipDeviceGetCount() returned %d\n", error);
+		exit(1);
+	}
+
+	if (rocm_device_id >= deviceCount) {
+		printf("Requested ROCm device %d but found only %d device(s)\n",
+               rocm_device_id, deviceCount);
+		return 1;
+	}
+
+	ROCM_CHECK(hipSetDevice(rocm_device_id));
+
+	hipDeviceProp_t prop = {0};
+	ROCM_CHECK(hipGetDeviceProperties(&prop, rocm_device_id));
+	printf("Using ROCm Device with ID: %d, Name: %s, PCI Bus ID: 0x%x, GCN Arch: %d\n",
+		   rocm_device_id, prop.name, prop.pciBusID, prop.gcnArch);
+
+	return 0;
+}
+
+static int pp_free_rocm(struct pingpong_context *ctx)
+{
+	return 0;
+}
+#endif
+
 static int pp_init_mmap(struct pingpong_context *ctx, size_t size,
 			const char *fname, unsigned long offset)
 {
@@ -1071,6 +1118,19 @@ int destroy_ctx(struct pingpong_context *ctx,
 	}
 	else
 	#endif
+	#ifdef HAVE_ROCM
+	if (user_param->use_rocm) {
+		for (i = 0; i < dereg_counter; i++) {
+			void *d_A = ctx->buf[i];
+
+			printf("deallocating GPU buffer %p\n", d_A);
+			hipFree(d_A);
+			d_A = 0;
+		}
+		pp_free_rocm(ctx);
+	}
+	else
+	#endif
 	if (user_param->mmap_file != NULL) {
 		pp_free_mmap(ctx);
 	} else if (ctx->is_contig_supported == FAILURE) {
@@ -1249,6 +1309,27 @@ int create_single_mr(struct pingpong_context *ctx, struct perftest_parameters *u
 		printf("allocated GPU buffer address at %016llx pointer=%p\n",
 		       d_A, (void *)d_A);
 		ctx->buf[qp_index] = (void *)d_A;
+	} else
+	#endif
+
+	#ifdef HAVE_ROCM
+	if (user_param->use_rocm) {
+		void* d_A;
+		hipError_t error;
+		const size_t gpu_page_size = 64 * 1024;
+		size_t size = (ctx->buff_size + gpu_page_size - 1) &
+			~(gpu_page_size - 1);
+
+		ctx->is_contig_supported = FAILURE;
+
+		error = hipMalloc(&d_A, size);
+		if (error != hipSuccess) {
+			printf("hipMalloc error=%d\n", error);
+			return FAILURE;
+		}
+
+		printf("allocated %zd bytes of GPU buffer at %p\n", size, d_A);
+		ctx->buf[qp_index] = d_A;
 	} else
 	#endif
 
@@ -1527,6 +1608,15 @@ int ctx_init(struct pingpong_context *ctx, struct perftest_parameters *user_para
 	if (user_param->use_cuda) {
 		if (pp_init_gpu(ctx, user_param->cuda_device_id)) {
 			fprintf(stderr, "Couldn't init GPU context\n");
+			return FAILURE;
+		}
+	}
+	#endif
+
+	#ifdef HAVE_ROCM
+	if (user_param->use_rocm) {
+		if (pp_init_rocm(ctx, user_param->rocm_device_id)) {
+			fprintf(stderr, "Couldn't initialize ROCm device\n");
 			return FAILURE;
 		}
 	}


### PR DESCRIPTION
Add support for allocating buffers on AMD GPUs through ROCm
 Works with Send/Read/Write verbs for Latency and BW tests

 To build with ROCm support, use:
 `$ ./configure --enable-rocm --with-rocm=/opt/rocm`

 To run with ROCm enabled on GPU#0, use:
 `$ ./ib_write_bw --use_rocm=0`

 Some D2D performance numbers on ConnectX-5 EDR
 measured with ib_send_lat and ib_send_bw:

 #bytes | Latency (us) | Bandwidth (Gb/s)
 -- | -- | --
 2 | 1.83 | 0.06
 4 | 1.76 | 0.21
 8 | 1.72 | 0.51
 16 | 1.76 | 1.03
 32 | 1.76 | 2.06
 64 | 1.74 | 4.12
 128 | 1.80 | 7.40
 256 | 1.83 | 16.52
 512 | 1.88 | 32.29
 1024 | 1.99 | 63.60
 2048 | 2.21 | 90.22
 4096 | 2.66 | 95.92
 8192 | 3.21 | 96.42
 16384 | 4.62 | 96.74
 32768 | 6.38 | 95.29
 65536 | 8.86 | 95.36
 131072 | 13.74 | 95.45
 262144 | 25.68 | 95.49
 524288 | 49.01 | 95.39
 1048576 | 95.74 | 95.39
 2097152 | 189.18 | 95.50
 4194304 | 376.12 | 95.42
 8388608 | 749.74 | 95.41