### PR TITLE
Add 0xefa1 pciid to the database

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1628,6 +1628,7 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 			case 55298 : dev_fname = NETXTREME; break;
 			case 55300 : dev_fname = NETXTREME; break;
 			case 61344 : dev_fname = EFA; break;
+			case 61345 : dev_fname = EFA; break;
 			default	   : dev_fname = UNKNOWN;
 		}
 	}


### PR DESCRIPTION
Add 0xefa1 ID to the devices database.

Signed-off-by: Gal Pressman <galpress@amazon.com>