### PR TITLE
Adjust max inline size for QLOGIC_E4 device

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1798,6 +1798,8 @@ static void ctx_set_max_inline(struct ibv_context *context,struct perftest_param
 				user_param->inline_size = 96;
 			else if (current_dev == EFA)
 				user_param->inline_size = 32;
+			else if (current_dev == QLOGIC_E4)
+				user_param->inline_size = 128;
 
 		} else {
 			user_param->inline_size = 0;


### PR DESCRIPTION
[  350.785441] [qedr_check_qp_attrs:1202(qedr1)]create qp: unsupported inline data size=0xec requested (max_inline=0x80)
[  350.898268] traps: ib_send_lat[30527] trap stack segment ip:7f374b039651 sp:7ffcf1ae0130 error:0 in librdmacm.so.1.2.29.0[7f374b030000+18000]
[  599.459433] [qedr_check_qp_attrs:1202(qedr1)]create qp: unsupported inline data size=0xdc requested (max_inline=0x80)
[  599.572268] traps: ib_write_lat[30751] trap stack segment ip:7ff66d1a6651 sp:7ffd27bf1ed0 error:0 in librdmacm.so.1.2.29.0[7ff66d19d000+18000]

Signed-off-by: Honggang Li <honli@redhat.com>