### PR TITLE
Check PCIe relaxed ordering compliant

### DIFF
--- a/README
+++ b/README
@@ -108,7 +108,8 @@ Prerequisites:
 	(kernel module) matches libibverbs
 	(kernel module) matches librdmacm
 	(kernel module) matches libibumad
-	(kernel module) matches libmath (lm).
+	(kernel module) matches libmath (lm)
+	(linux kernel module) matches pciutils (lpci).
 	
 
 Server:		./<test name> <options>

--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,8 @@ if [test $HAVE_SNIFFER = yes]; then
 fi
 
 if [test $IS_FREEBSD = no]; then
+	AC_CHECK_HEADERS([pci/pci.h],,[AC_MSG_ERROR([pciutils header files not found, consider installing pciutils-devel])])
+	AC_CHECK_LIB([pci], [pci_init], [LIBPCI=-lpci], AC_MSG_ERROR([libpci not found]))
 	CPU_IS_RO_COMPLIANT=yes
 	# Actually this is check for being affected by a known issue
 	# with Intel CPUs:
@@ -193,6 +195,7 @@ AC_TRY_LINK([
 AM_CONDITIONAL([HAVE_RO],[test "x$HAVE_RO" = "xyes"])
 if [test $HAVE_RO = yes] && [test "x$CPU_IS_RO_COMPLIANT" = "xyes"]; then
         AC_DEFINE([HAVE_RO], [1], [Enable Relaxed Ordering])
+	LIBS=$LIBS" -lpci"
 fi
 
 AC_TRY_LINK([#include <infiniband/verbs.h>],

--- a/perftest.spec
+++ b/perftest.spec
@@ -8,6 +8,7 @@ Source:         http://www.openfabrics.org/downloads/%{name}-%{version}.tar.gz
 Url:            http://www.openfabrics.org
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  libibverbs-devel librdmacm-devel libibumad-devel
+BuildRequires:  pciutils-devel
 
 %description
 gen3 uverbs microbenchmarks


### PR DESCRIPTION
Significantly performance degradation may be observed when PICe
relaxed ordering enabled over CPU which is not PCIe RP compliant.
Emit a warning message for such scenario.

https://github.com/linux-rdma/perftest/issues/116

Signed-off-by: Honggang Li <honli@redhat.com>