### PR TITLE
Fix autogen script

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,8 +2,8 @@
 
 test -d ./config || mkdir ./config
 mkdir -p m4 config/m4 config/aux
-aclocal -I config
 libtoolize --force --copy
+aclocal -I config
 autoheader
 automake --foreign --add-missing --copy
 autoconf


### PR DESCRIPTION
libtool also installs some m4 macros, so if libtoolize is not executed
before aclocal, aclocal may pick up other versions of libtool m4 macros
already bundled into the software.

Example error:
```
libtool: Version mismatch error.  This is libtool 2.4.6, but the
libtool: definition of this LT_INIT comes from libtool 2.4.2.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.6
libtool: and run autoconf again.
```
Fix this by changing the order of aclocal and libtoolize in autogen.sh