### PR TITLE
Do not check if CPU is RO compliant at compile time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,16 +185,6 @@ if [test $IS_FREEBSD = no]; then
 	AC_CHECK_HEADERS([pci/pci.h],,[AC_MSG_ERROR([pciutils header files not found, consider installing pciutils-devel])])
 	AC_CHECK_LIB([pci], [pci_init], [LIBPCI=-lpci], AC_MSG_ERROR([libpci not found]))
 	CPU_IS_RO_COMPLIANT=yes
-	# Actually this is check for being affected by a known issue
-	# with Intel CPUs:
-	# https://lore.kernel.org/patchwork/patch/820922/
-	intel_no_ro_devices="6f01 6f02 6f03 6f04 6f05 6f06 6f07 6f08 6f09 6f0a 6f0b 6f0c 6f0d 6f0e 2f01 2f02 2f03 2f04 2f05 2f06 2f07 2f08 2f09 2f0a 2f0b 2f0c 2f0d 2f0e"
-	for cpu_num in $intel_no_ro_devices; do
-		ro_nonsupported=$(lspci -nn | grep -i 8086:$cpu_num)
-		if [ test "$ro_nonsupported" ]; then
-			CPU_IS_RO_COMPLIANT=no
-		fi
-	done
 fi
 
 AC_TRY_LINK([


### PR DESCRIPTION
Patch d157d4246abe (Check PCIe relaxed ordering compliant) introduced run-time check
for relaxed ordering compliance. Thus there shouldn't be any compile time checks.
Current code is at risk on behaving differently on the same machine depending on which
CPU it was packaged.

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>