### PR TITLE
SRD CQ notifications

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1406,11 +1406,6 @@ static void force_dependecies(struct perftest_parameters *user_param)
 			fprintf(stderr, " SRD does not support RDMA_CM\n");
 			exit(1);
 		}
-		if (user_param->use_event == ON) {
-			printf(RESULT_LINE);
-			fprintf(stderr, " SRD does not support events\n");
-			exit(1);
-		}
 		user_param->cq_mod = 1;
 	}
 

--- a/src/raw_ethernet_resources.c
+++ b/src/raw_ethernet_resources.c
@@ -1005,8 +1005,7 @@ int run_iter_fw(struct pingpong_context *ctx,struct perftest_parameters *user_pa
 		}
 
 		if (user_param->use_event) {
-
-			if (ctx_notify_events(ctx->channel)) {
+			if (ctx_notify_send_recv_events(ctx)) {
 				fprintf(stderr, "Failed to notify events to CQ");
 				return_value = FAILURE;
 				goto cleaning;


### PR DESCRIPTION
Add support for SRD CQ notifications.
The first patch fixes a bug where the same completion channel is used for both TX and RX and messes up the test.