### PR TITLE
RISC-V support

### DIFF
--- a/src/get_clock.c
+++ b/src/get_clock.c
@@ -237,3 +237,65 @@ double get_cpu_mhz(int no_cpu_freq_warn)
 	return proc;
 #endif
 }
+
+#if defined(__riscv)
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <linux/perf_event.h>
+#include <asm/unistd.h>
+
+static long perf_event_open(struct perf_event_attr *hw_event,
+		pid_t pid, int cpu, int group_fd,
+		unsigned long flags)
+{
+	return syscall(__NR_perf_event_open, hw_event, pid,
+			cpu, group_fd, flags);
+}
+
+cycles_t perf_get_cycles()
+{
+	cycles_t cycles = 0;
+	struct perf_event_attr pe;
+	const pid_t pid = 0;		// Current task
+	const int cpu = -1;  		// On any CPU
+	const int group_fd = -1;	// Use leader group
+	const unsigned long flags = 0;
+	/* Use this variable just to open perf event here and once.
+	   It is appropriate because it touches only this function and
+	   not fix other code */
+	static int is_open = 0;
+	/* Make file discriptor static just to keep it valid during
+	   programm execution. It will be closed automatically when
+	   test finishes. It is a hack just not to fix other part of test */
+        static int fd = -1;
+
+	if (!is_open) {
+		memset(&pe, 0, sizeof(pe));
+
+		pe.type = PERF_TYPE_HARDWARE;
+		pe.size = sizeof(pe);
+		pe.config = PERF_COUNT_HW_CPU_CYCLES;
+		pe.disabled = 0;
+		pe.exclude_kernel = 0;
+		pe.exclude_hv = 0;
+
+		fd = perf_event_open(&pe, pid, cpu, group_fd, flags);
+		if (fd == -1) {
+			fprintf(stderr, "Error opening perf event (%llx)\n", pe.config);
+			exit(EXIT_FAILURE);
+		}
+
+		is_open = 1;
+	}
+
+	if(read(fd, &cycles, sizeof(cycles)) < 0) {
+		fprintf(stderr, "Error reading perf event (%llx)\n", pe.config);
+		exit(EXIT_FAILURE);
+	}
+
+	return cycles;
+}
+#endif

--- a/src/get_clock.c
+++ b/src/get_clock.c
@@ -222,6 +222,11 @@ double get_cpu_mhz(int no_cpu_freq_warn)
 	if (proc < 1)
 		proc = sample;
 	#endif
+	#ifdef __riscv
+	if (proc <= 0)
+		proc = sample;
+	#endif
+
 	if (!proc || !sample)
 		return 0;
 

--- a/src/get_clock.h
+++ b/src/get_clock.h
@@ -104,6 +104,15 @@ static inline cycles_t get_cycles()
 	asm volatile("mrs %0, cntvct_el0" : "=r" (cval));
 	return cval;
 }
+#elif defined(__riscv)
+typedef unsigned long cycles_t;
+
+cycles_t perf_get_cycles();
+
+static inline cycles_t get_cycles()
+{
+	return perf_get_cycles();
+}
 
 #else
 #warning get_cycles not implemented for this architecture: attempt asm/timex.h

--- a/src/get_clock.h
+++ b/src/get_clock.h
@@ -104,38 +104,7 @@ static inline cycles_t get_cycles()
 	asm volatile("mrs %0, cntvct_el0" : "=r" (cval));
 	return cval;
 }
-#elif defined(__riscv)
-#define ASM_STR(x) #x
-#define csr_read(csr)						\
-({								\
-	register unsigned long __v;				\
-	__asm__ __volatile__ ("csrr %0, " ASM_STR(csr)          \
-			      : "=r" (__v) :			\
-			      : "memory");			\
-	__v;							\
-})//read mtime csr
-#define CSR_TIME		0xc01  //read mtime from csrs rather than the mmap
-#if  __riscv_xlen == 64
-typedef unsigned long long cycles_t;
-static inline cycles_t get_cycles()
-{
-	return csr_read(CSR_TIME);
-}
-#elif __riscv_xlen == 32
-#define CSR_TIMEH		0xc81
-typedef unsigned long long cycles_t;
-static inline cycles_t get_cycles()
-{	uint32_t hi, lo;
 
-	do {
-		hi = csr_read(CSR_TIMEH);
-		lo = csr_read(CSR_TIME);
-	} while (hi != csr_read(CSR_TIMEH));
-
-	return ((uint64_t)hi << 32) | lo;
-
-}
-#endif/*__riscv*/
 #else
 #warning get_cycles not implemented for this architecture: attempt asm/timex.h
 #include <asm/timex.h>


### PR DESCRIPTION
This patchset adds support for RISC-V arch. It also solves Issue #133 .

It is tested and successfully used on SiFive HiFive Unmatched board. Unmatched runs under Linux 5.16.0.
Our test bench consists of one IntelXeon Bronze 3204 with 8 cores, one Unmatched board and two Mellanox mlx5 network cards. The link is set to 25 Gbit/s
Test results give almost all link bandwidth. 


**For example, ib_write_bw test on Unmatched board:**
```
localhost:~ # ib_write_bw -F 10.10.0.2 --report_gbits
---------------------------------------------------------------------------------------
                    RDMA_Write BW Test
 Dual-port       : OFF          Device         : mlx5_0
 Number of qps   : 1            Transport type : IB
 Connection type : RC           Using SRQ      : OFF
 PCIe relax order: ON
 ibv_wr* API     : ON
 TX depth        : 128
 CQ Moderation   : 1
 Mtu             : 1024[B]
 Link type       : Ethernet
 GID index       : 3
 Max inline data : 0[B]
 rdma_cm QPs     : OFF
 Data ex. method : Ethernet
---------------------------------------------------------------------------------------
 local address: LID 0000 QPN 0x0110 PSN 0x35a41b RKey 0x17f2e7 VAddr 0x00003fa745b000
 GID: 00:00:00:00:00:00:00:00:00:00:255:255:10:10:00:01
 remote address: LID 0000 QPN 0x01b5 PSN 0xa7eb1 RKey 0x17ed88 VAddr 0x007f9c48c57000
 GID: 00:00:00:00:00:00:00:00:00:00:255:255:10:10:00:02
---------------------------------------------------------------------------------------
 #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]
 65536      5000             23.13              23.13              0.044122
---------------------------------------------------------------------------------------
```

```
localhost:~ # ethtool enp7s0f0np0                                                                     
Settings for enp7s0f0np0: 
        ....
        Speed: 25000Mb/s
        ...
```
