### PR TITLE
Fix documentation com_rdma_cm -> comm_rdma_cm

### DIFF
--- a/README
+++ b/README
@@ -149,7 +149,7 @@ Common Options to all tests:
   -h, --help				Display this help message screen
   -p, --port=<port>			Listen on/connect to port <port> (default: 18515)
   -R, --rdma_cm				Connect QPs with rdma_cm and run test on those QPs
-  -z, --com_rdma_cm			Communicate with rdma_cm module to exchange data - use regular QPs
+  -z, --comm_rdma_cm			Communicate with rdma_cm module to exchange data - use regular QPs
   -m, --mtu=<mtu>			QP Mtu size (default: active_mtu from ibv_devinfo)
   -c, --connection=<type>		Connection type RC/UC/UD/XRC/DC/SRD (default RC).
   -d, --ib-dev=<dev>			Use IB device <dev> (default: first device found)

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -416,7 +416,7 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 	}
 
 	if (connection_type != RawEth) {
-		printf("  -z, --com_rdma_cm ");
+		printf("  -z, --comm_rdma_cm ");
 		printf(" Communicate with rdma_cm module to exchange data - use regular QPs\n");
 	}
 


### PR DESCRIPTION
Proper parameter name follows int parser(...):

{ .name = "comm_rdma_cm",	.has_arg = 0, .val = 'z' },
