### PR TITLE
[Feature] Fix Indentation Alignment

### DIFF
--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -554,9 +554,10 @@ int run_iter_bw(struct pingpong_context *ctx,struct perftest_parameters *user_pa
  *
  *	ctx     - Test Context.
  *	user_param  - user_parameters struct for this test.
+ *	indentation_output - Indentation object.
  *
  */
-int run_iter_bw_infinitely(struct pingpong_context *ctx,struct perftest_parameters *user_param);
+int run_iter_bw_infinitely(struct pingpong_context *ctx,struct perftest_parameters *user_param, struct indentation_output *io_obj);
 
 /* run_iter_bw_infinitely_server
  *
@@ -568,9 +569,10 @@ int run_iter_bw_infinitely(struct pingpong_context *ctx,struct perftest_paramete
  *
  *	ctx     - Test Context.
  *	user_param  - user_parameters struct for this test.
+ *	indentation_output - Indentation object.
  *
  */
-int run_iter_bw_infinitely_server(struct pingpong_context *ctx, struct perftest_parameters *user_param);
+int run_iter_bw_infinitely_server(struct pingpong_context *ctx, struct perftest_parameters *user_param, struct indentation_output *io_obj);
 
 /* run_iter_bw_server.
  *
@@ -767,14 +769,14 @@ void catch_alarm(int sig);
 
 void check_alive(int sig);
 
-void print_bw_infinite_mode();
+void print_bw_infinite_mode(struct indentation_output *io_obj);
 
 /* handle_signal_print_thread
 *
 * Description :
 * 	Handle thread creation for printing data in run_infinitely mode
 **/
-void *handle_signal_print_thread(void* duration);
+void *handle_signal_print_thread(void* thr_arg);
 
 int perform_warm_up(struct pingpong_context *ctx,struct perftest_parameters *user_param);
 

--- a/src/read_bw.c
+++ b/src/read_bw.c
@@ -55,6 +55,7 @@ int main(int argc, char *argv[])
 	struct perftest_parameters user_param;
 	struct perftest_comm	   user_comm;
 	struct bw_report_data      my_bw_rep, rem_bw_rep;
+	struct indentation_output *io_obj = init_indentation_obj();
 
 	/* init default values to user's parameters */
 	memset(&ctx,0,sizeof(struct pingpong_context));
@@ -225,9 +226,9 @@ int main(int argc, char *argv[])
 		}
 		else {
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			user_param.report_fmt == MBS ? print_header_line(io_obj, RESULT_FMT) : print_header_line(io_obj, RESULT_FMT_G);
 		}
-		printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
+		user_param.cpu_util_data.enable ? print_header_line(io_obj, RESULT_EXT_CPU_UTIL) : printf(RESULT_EXT);
 	}
 
 	/* For half duplex tests, server just waits for client to exit */
@@ -239,7 +240,7 @@ int main(int argc, char *argv[])
 		}
 
 		xchg_bw_reports(&user_comm, &my_bw_rep,&rem_bw_rep,atof(user_param.rem_version));
-		print_full_bw_report(&user_param, &rem_bw_rep, NULL);
+		print_full_bw_report(&user_param, &rem_bw_rep, NULL, io_obj);
 
 		if (ctx_close_connection(&user_comm,&my_dest[0],&rem_dest[0])) {
 			fprintf(stderr,"Failed to close connection between server and client\n");
@@ -303,11 +304,11 @@ int main(int argc, char *argv[])
 				}
 			}
 
-			print_report_bw(&user_param,&my_bw_rep);
+			print_report_bw(&user_param,&my_bw_rep,io_obj);
 
 			if (user_param.duplex) {
 				xchg_bw_reports(&user_comm, &my_bw_rep,&rem_bw_rep,atof(user_param.rem_version));
-				print_full_bw_report(&user_param, &my_bw_rep, &rem_bw_rep);
+				print_full_bw_report(&user_param, &my_bw_rep, &rem_bw_rep, io_obj);
 			}
 		}
 
@@ -333,33 +334,37 @@ int main(int argc, char *argv[])
 			return FAILURE;
 		}
 
-		print_report_bw(&user_param,&my_bw_rep);
+		print_report_bw(&user_param,&my_bw_rep,io_obj);
 
 		if (user_param.duplex) {
 			xchg_bw_reports(&user_comm, &my_bw_rep,&rem_bw_rep,atof(user_param.rem_version));
-			print_full_bw_report(&user_param, &my_bw_rep, &rem_bw_rep);
+			print_full_bw_report(&user_param, &my_bw_rep, &rem_bw_rep, io_obj);
 		}
+
+		clear_indentation_data(io_obj);
 
 		if (user_param.report_both && user_param.duplex) {
 			printf(RESULT_LINE);
 			printf("\n Local results: \n");
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
-			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
-			print_full_bw_report(&user_param, &my_bw_rep, NULL);
+			user_param.report_fmt == MBS ? print_header_line(io_obj, RESULT_FMT) : print_header_line(io_obj, RESULT_FMT_G);
+			user_param.cpu_util_data.enable ? print_header_line(io_obj, RESULT_EXT_CPU_UTIL) : printf(RESULT_EXT);
+			print_full_bw_report(&user_param, &my_bw_rep, NULL, io_obj);
 			printf(RESULT_LINE);
+
+			clear_indentation_data(io_obj);
 
 			printf("\n Remote results: \n");
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
-			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
-			print_full_bw_report(&user_param, &rem_bw_rep, NULL);
+			user_param.report_fmt == MBS ? print_header_line(io_obj, RESULT_FMT) : print_header_line(io_obj, RESULT_FMT_G);
+			user_param.cpu_util_data.enable ? print_header_line(io_obj, RESULT_EXT_CPU_UTIL) : printf(RESULT_EXT);
+			print_full_bw_report(&user_param, &rem_bw_rep, NULL, io_obj);
 		}
 	} else if (user_param.test_method == RUN_INFINITELY) {
 
 		ctx_set_send_wqes(&ctx,&user_param,rem_dest);
 
-		if(run_iter_bw_infinitely(&ctx,&user_param)) {
+		if(run_iter_bw_infinitely(&ctx,&user_param,io_obj)) {
 			fprintf(stderr," Error occurred while running! aborting ...\n");
 			return FAILURE;
 		}
@@ -407,6 +412,8 @@ int main(int argc, char *argv[])
 		user_comm.rdma_params->work_rdma_cm = OFF;
 		return destroy_ctx(user_comm.rdma_ctx,user_comm.rdma_params);
 	}
+
+	destroy_indentation_obj(&io_obj);
 
 	return destroy_ctx(&ctx,&user_param);
 }

--- a/src/send_bw.c
+++ b/src/send_bw.c
@@ -164,6 +164,7 @@ int main(int argc, char *argv[])
 	struct bw_report_data		my_bw_rep, rem_bw_rep;
 	int                      	ret_parser, i = 0, rc;
 	int                      	size_max_pow = 24;
+	struct indentation_output *io_obj = init_indentation_obj();
 
 	/* init default values to user's parameters */
 	memset(&ctx, 0,sizeof(struct pingpong_context));
@@ -390,9 +391,9 @@ int main(int argc, char *argv[])
 		}
 		else {
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			user_param.report_fmt == MBS ? print_header_line(io_obj, RESULT_FMT) : print_header_line(io_obj, RESULT_FMT_G);
 		}
-		printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
+		user_param.cpu_util_data.enable ? print_header_line(io_obj, RESULT_EXT_CPU_UTIL) : printf(RESULT_EXT);
 	}
 
 	if (user_param.test_method == RUN_ALL) {
@@ -443,11 +444,11 @@ int main(int argc, char *argv[])
 				}
 			}
 
-			print_report_bw(&user_param,&my_bw_rep);
+			print_report_bw(&user_param,&my_bw_rep,io_obj);
 
 			if (user_param.duplex && user_param.test_type != DURATION) {
 				xchg_bw_reports(&user_comm, &my_bw_rep,&rem_bw_rep,atof(user_param.rem_version));
-				print_full_bw_report(&user_param, &my_bw_rep, &rem_bw_rep);
+				print_full_bw_report(&user_param, &my_bw_rep, &rem_bw_rep, io_obj);
 			}
 			if (ctx_hand_shake(&user_comm,&my_dest[0],&rem_dest[0])) {
 				fprintf(stderr,"Failed to exchange data between server and clients\n");
@@ -493,27 +494,31 @@ int main(int argc, char *argv[])
 			return 17;
 		}
 
-		print_report_bw(&user_param,&my_bw_rep);
+		print_report_bw(&user_param,&my_bw_rep,io_obj);
 
 		if (user_param.duplex && user_param.test_type != DURATION) {
 			xchg_bw_reports(&user_comm, &my_bw_rep,&rem_bw_rep,atof(user_param.rem_version));
-			print_full_bw_report(&user_param, &my_bw_rep, &rem_bw_rep);
+			print_full_bw_report(&user_param, &my_bw_rep, &rem_bw_rep, io_obj);
 		}
+
+		clear_indentation_data(io_obj);
 
 		if (user_param.report_both && user_param.duplex) {
 			printf(RESULT_LINE);
 			printf("\n Local results: \n");
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
-			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
-			print_full_bw_report(&user_param, &my_bw_rep, NULL);
+			user_param.report_fmt == MBS ? print_header_line(io_obj, RESULT_FMT) : print_header_line(io_obj, RESULT_FMT_G);
+			user_param.cpu_util_data.enable ? print_header_line(io_obj, RESULT_EXT_CPU_UTIL) : printf(RESULT_EXT);
+			print_full_bw_report(&user_param, &my_bw_rep, NULL, io_obj);
 			printf(RESULT_LINE);
+
+			clear_indentation_data(io_obj);
 
 			printf("\n Remote results: \n");
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
-			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
-			print_full_bw_report(&user_param, &rem_bw_rep, NULL);
+			user_param.report_fmt == MBS ? print_header_line(io_obj, RESULT_FMT) : print_header_line(io_obj, RESULT_FMT_G);
+			user_param.cpu_util_data.enable ? print_header_line(io_obj, RESULT_EXT_CPU_UTIL) : printf(RESULT_EXT);
+			print_full_bw_report(&user_param, &rem_bw_rep, NULL, io_obj);
 		}
 	} else if (user_param.test_method == RUN_INFINITELY) {
 
@@ -535,14 +540,14 @@ int main(int argc, char *argv[])
 
 		if (user_param.machine == CLIENT) {
 
-			if(run_iter_bw_infinitely(&ctx,&user_param)) {
+			if(run_iter_bw_infinitely(&ctx,&user_param,io_obj)) {
 				fprintf(stderr," Error occurred while running infinitely! aborting ...\n");
 				return FAILURE;
 			}
 
 		} else if (user_param.machine == SERVER) {
 
-			if(run_iter_bw_infinitely_server(&ctx,&user_param)) {
+			if(run_iter_bw_infinitely_server(&ctx,&user_param,io_obj)) {
 				fprintf(stderr," Error occurred while running infinitely on server! aborting ...\n");
 				return FAILURE;
 			}
@@ -583,6 +588,8 @@ int main(int argc, char *argv[])
 		fprintf(stderr,"Error: Msg rate  is below msg_rate limit\n");
 		return FAILURE;
 	}
+
+	destroy_indentation_obj(&io_obj);
 
 	return 0;
 }


### PR DESCRIPTION
Currently, in perftest, when a user makes a traffic of bandwidth applications, the results of the traffic will not be aligned under each column of the Header i.e. (RESULT_FMT).

Using this commit, the x_bw perftest outputs will be presented in an organized manner for all cases (flag options).