### PR TITLE
Perftest code fix and optimization

### DIFF
--- a/src/atomic_bw.c
+++ b/src/atomic_bw.c
@@ -116,6 +116,7 @@ int main(int argc, char *argv[])
 	/* Initialize the connection and print the local data. */
 	if (establish_connection(&user_comm)) {
 		fprintf(stderr, " Unable to init the socket connection\n");
+		dealloc_comm_struct(&user_comm, &user_param);
 		return FAILURE;
 	}
 
@@ -126,16 +127,21 @@ int main(int argc, char *argv[])
 	/* See if MTU and link type are valid and supported. */
 	if (check_mtu(ctx.context, &user_param, &user_comm)) {
 		fprintf(stderr, " Couldn't get context for the device\n");
+		dealloc_comm_struct(&user_comm, &user_param);
 		return FAILURE;
 	}
 
-	ALLOCATE(my_dest, struct pingpong_dest, user_param.num_of_qps);
+	MAIN_ALLOC(my_dest, struct pingpong_dest, user_param.num_of_qps, return_error);
 	memset(my_dest, 0, sizeof(struct pingpong_dest)*user_param.num_of_qps);
-	ALLOCATE(rem_dest, struct pingpong_dest, user_param.num_of_qps);
+	MAIN_ALLOC(rem_dest, struct pingpong_dest, user_param.num_of_qps, free_rem_dest);
 	memset(rem_dest, 0, sizeof(struct pingpong_dest)*user_param.num_of_qps);
 
 	/* Allocating arrays needed for the test. */
-	alloc_ctx(&ctx, &user_param);
+	if(alloc_ctx(&ctx,&user_param)){
+		fprintf(stderr, "Couldn't allocate context\n");
+		dealloc_comm_struct(&user_comm, &user_param);
+		goto free_mem;
+	}
 
 	/* Create RDMA CM resources and connect through CM. */
 	if (user_param.work_rdma_cm == ON) {
@@ -144,20 +150,24 @@ int main(int argc, char *argv[])
 		if (rc) {
 			fprintf(stderr,
 				"Failed to create RDMA CM connection with resources.\n");
-			return FAILURE;
+			dealloc_comm_struct(&user_comm, &user_param);
+			dealloc_ctx(&ctx, &user_param);
+			goto free_mem;
 		}
 	} else {
 		/* create all the basic IB resources. */
 		if (ctx_init(&ctx, &user_param)) {
 			fprintf(stderr, " Couldn't create IB resources\n");
-			return FAILURE;
+			dealloc_comm_struct(&user_comm, &user_param);
+			dealloc_ctx(&ctx, &user_param);
+			goto free_mem;
 		}
 	}
 
 	/* Set up the Connection. */
 	if (set_up_connection(&ctx, &user_param, my_dest)) {
 		fprintf(stderr, " Unable to set up socket connection\n");
-		return FAILURE;
+		goto destroy_context;
 	}
 
 	/* Print basic test information. */
@@ -168,7 +178,7 @@ int main(int argc, char *argv[])
 		/* shaking hands and gather the other side info. */
 		if (ctx_hand_shake(&user_comm, &my_dest[i], &rem_dest[i])) {
 			fprintf(stderr, "Failed to exchange data between server and clients\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 	}
 
@@ -176,14 +186,14 @@ int main(int argc, char *argv[])
 		if (ctx_check_gid_compatibility(&my_dest[0], &rem_dest[0])) {
 			fprintf(stderr, "\n Found Incompatibility issue with GID types.\n");
 			fprintf(stderr, " Please Try to use a different IP version.\n\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 	}
 
 	if (user_param.work_rdma_cm == OFF) {
 		if (ctx_connect(&ctx, rem_dest, &user_param, my_dest)) {
 			fprintf(stderr, " Unable to Connect the HCA's through the link\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 	}
 
@@ -192,7 +202,7 @@ int main(int argc, char *argv[])
 		/* Set up connection one more time to send qpn properly for DC */
 		if (set_up_connection(&ctx,&user_param,my_dest)) {
 			fprintf(stderr," Unable to set up socket connection\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 	}
 
@@ -207,7 +217,7 @@ int main(int argc, char *argv[])
 
 		if (ctx_hand_shake(&user_comm,&my_dest[i],&rem_dest[i])) {
 			fprintf(stderr," Failed to exchange data between server and clients\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 
 		ctx_print_pingpong_data(&rem_dest[i],&user_comm);
@@ -216,7 +226,7 @@ int main(int argc, char *argv[])
 	/* An additional handshake is required after moving qp to RTR. */
 	if (ctx_hand_shake(&user_comm, &my_dest[0], &rem_dest[0])) {
 		fprintf(stderr, "Failed to exchange data between server and clients\n");
-		return FAILURE;
+		goto destroy_context;
 	}
 
 	/* For half duplex tests, server just waits for client to exit */
@@ -229,7 +239,7 @@ int main(int argc, char *argv[])
 
 		if (ctx_hand_shake(&user_comm, &my_dest[0], &rem_dest[0])) {
 			fprintf(stderr, " Failed to exchange data between server and clients\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 
 		xchg_bw_reports(&user_comm, &my_bw_rep, &rem_bw_rep, atof(user_param.rem_version));
@@ -241,26 +251,28 @@ int main(int argc, char *argv[])
 
 		if (ctx_close_connection(&user_comm, &my_dest[0], &rem_dest[0])) {
 			fprintf(stderr, "Failed to close connection between server and client\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 
 		if (user_param.work_rdma_cm == ON) {
 			if (destroy_ctx(&ctx, &user_param)) {
 				fprintf(stderr, "Failed to destroy resources.\n");
-				return FAILURE;
+				goto destroy_cm_context;
 			}
-
+			free(my_dest);
+			free(rem_dest);
 			user_comm.rdma_params->work_rdma_cm = OFF;
 			return destroy_ctx(user_comm.rdma_ctx, user_comm.rdma_params);
 		}
-
+		free(my_dest);
+		free(rem_dest);
 		return destroy_ctx(&ctx, &user_param);
 	}
 
 	if (user_param.use_event) {
 		if (ibv_req_notify_cq(ctx.send_cq, 0)) {
 			fprintf(stderr, "Couldn't request CQ notification\n");
-			return FAILURE;
+			goto free_mem;
 		}
 	}
 	if (user_param.output == FULL_VERBOSITY) {
@@ -276,20 +288,20 @@ int main(int argc, char *argv[])
 		if (user_param.perform_warm_up) {
 			if (perform_warm_up(&ctx, &user_param)) {
 				fprintf(stderr, "Problems with warm up\n");
-				return FAILURE;
+				goto free_mem;
 			}
 		}
 
 		if (user_param.duplex) {
 			if (ctx_hand_shake(&user_comm, &my_dest[0], &rem_dest[0])) {
 				fprintf(stderr, "Failed to sync between server and client between different msg sizes\n");
-				return FAILURE;
+				goto free_mem;
 			}
 		}
 
 		if (run_iter_bw(&ctx, &user_param)) {
 			fprintf(stderr, " Error occurred in run_iter function\n");
-			return FAILURE;
+			goto free_mem;
 		}
 
 		print_report_bw(&user_param, &my_bw_rep);
@@ -318,7 +330,7 @@ int main(int argc, char *argv[])
 
 		if (run_iter_bw_infinitely(&ctx, &user_param)) {
 			fprintf(stderr, " Error occurred while running infinitely! aborting ...\n");
-			return FAILURE;
+			goto free_mem;
 		}
 	}
 
@@ -330,7 +342,7 @@ int main(int argc, char *argv[])
 
 		if (ctx_hand_shake(&user_comm, &my_dest[0], &rem_dest[0])) {
 			fprintf(stderr, " Failed to exchange data between server and clients\n");
-			return FAILURE;
+			goto free_mem;
 		}
 
 		xchg_bw_reports(&user_comm, &my_bw_rep, &rem_bw_rep, atof(user_param.rem_version));
@@ -338,28 +350,49 @@ int main(int argc, char *argv[])
 
 	if (ctx_close_connection(&user_comm, &my_dest[0], &rem_dest[0])) {
 		fprintf(stderr, "Failed to close connection between server and client\n");
-		return FAILURE;
+		goto free_mem;
 	}
 
 	if (!user_param.is_bw_limit_passed && (user_param.is_limit_bw == ON)) {
 		fprintf(stderr, "Error: BW result is below bw limit\n");
-		return FAILURE;
+		goto destroy_context;
 	}
 
 	if (!user_param.is_msgrate_limit_passed && (user_param.is_limit_bw == ON)) {
 		fprintf(stderr, "Error: Msg rate  is below msg_rate limit\n");
-		return FAILURE;
+		goto destroy_context;
 	}
 
 	if (user_param.work_rdma_cm == ON) {
 		if (destroy_ctx(&ctx, &user_param)) {
 			fprintf(stderr, "Failed to destroy resources.\n");
-			return FAILURE;
+			goto destroy_cm_context;
 		}
 
 		user_comm.rdma_params->work_rdma_cm = OFF;
+		free(my_dest);
+		free(rem_dest);
 		return destroy_ctx(user_comm.rdma_ctx, user_comm.rdma_params);
 	}
 
+	free(my_dest);
+	free(rem_dest);
+
 	return destroy_ctx(&ctx, &user_param);
+
+destroy_context:
+	if (destroy_ctx(&ctx,&user_param))
+		fprintf(stderr, "Failed to destroy resources\n");
+destroy_cm_context:
+	if (user_param.work_rdma_cm == ON) {
+		user_comm.rdma_params->work_rdma_cm = OFF;
+		destroy_ctx(user_comm.rdma_ctx,user_comm.rdma_params);
+	}
+free_mem:
+	free(my_dest);
+free_rem_dest:
+	free(rem_dest);
+return_error:
+	return FAILURE;
+
 }

--- a/src/atomic_lat.c
+++ b/src/atomic_lat.c
@@ -54,7 +54,7 @@
  ******************************************************************************/
 int main(int argc, char *argv[])
 {
-	int				ret_parser, i, rc;
+	int				ret_parser, i, rc, error = 1;
 	struct report_options		report;
 	struct pingpong_context		ctx;
 	struct pingpong_dest		*my_dest  = NULL;
@@ -125,6 +125,7 @@ int main(int argc, char *argv[])
 	/* Initialize the connection and print the local data. */
 	if (establish_connection(&user_comm)) {
 		fprintf(stderr," Unable to init the socket connection\n");
+		dealloc_comm_struct(&user_comm, &user_param);
 		return FAILURE;
 	}
 
@@ -135,16 +136,21 @@ int main(int argc, char *argv[])
 	/* See if MTU and link type are valid and supported. */
 	if (check_mtu(ctx.context,&user_param, &user_comm)) {
 		fprintf(stderr, " Couldn't get context for the device\n");
+		dealloc_comm_struct(&user_comm, &user_param);
 		return FAILURE;
 	}
 
-	ALLOCATE(my_dest , struct pingpong_dest , user_param.num_of_qps);
+	MAIN_ALLOC(my_dest , struct pingpong_dest , user_param.num_of_qps , return_error);
 	memset(my_dest, 0, sizeof(struct pingpong_dest)*user_param.num_of_qps);
-	ALLOCATE(rem_dest , struct pingpong_dest , user_param.num_of_qps);
+	MAIN_ALLOC(rem_dest , struct pingpong_dest , user_param.num_of_qps , free_rem_dest);
 	memset(rem_dest, 0, sizeof(struct pingpong_dest)*user_param.num_of_qps);
 
 	/* Allocating arrays needed for the test. */
-	alloc_ctx(&ctx,&user_param);
+	if (alloc_ctx(&ctx,&user_param)){
+		fprintf(stderr, "Couldn't allocate context\n");
+		dealloc_comm_struct(&user_comm, &user_param);
+		goto free_mem;
+	}
 
 	/* Create RDMA CM resources and connect through CM. */
 	if (user_param.work_rdma_cm == ON) {
@@ -153,20 +159,24 @@ int main(int argc, char *argv[])
 		if (rc) {
 			fprintf(stderr,
 				"Failed to create RDMA CM connection with resources.\n");
-			return FAILURE;
+			dealloc_comm_struct(&user_comm,&user_param);
+			dealloc_ctx(&ctx, &user_param);
+			goto free_mem;
 		}
 	} else {
 		/* create all the basic IB resources (data buffer, PD, MR, CQ and events channel) */
 		if (ctx_init(&ctx,&user_param)) {
 			fprintf(stderr, " Couldn't create IB resources\n");
-			return FAILURE;
+			dealloc_comm_struct(&user_comm,&user_param);
+			dealloc_ctx(&ctx, &user_param);
+			goto free_mem;
 		}
 	}
 
 	/* Set up the Connection. */
 	if (set_up_connection(&ctx,&user_param,my_dest)) {
 		fprintf(stderr," Unable to set up socket connection\n");
-		return FAILURE;
+		goto destroy_context;
 	}
 
 	/* Print basic test information. */
@@ -175,7 +185,7 @@ int main(int argc, char *argv[])
 	/* shaking hands and gather the other side info. */
 	if (ctx_hand_shake(&user_comm,my_dest,rem_dest)) {
 		fprintf(stderr,"Failed to exchange data between server and clients\n");
-		return FAILURE;
+		goto destroy_context;
 	}
 
 	for (i=0; i < user_param.num_of_qps; i++) {
@@ -183,7 +193,7 @@ int main(int argc, char *argv[])
 		/* shaking hands and gather the other side info. */
 		if (ctx_hand_shake(&user_comm,&my_dest[i],&rem_dest[i])) {
 			fprintf(stderr,"Failed to exchange data between server and clients\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 	}
 
@@ -191,14 +201,14 @@ int main(int argc, char *argv[])
 		if (ctx_check_gid_compatibility(&my_dest[0], &rem_dest[0])) {
 			fprintf(stderr,"\n Found Incompatibility issue with GID types.\n");
 			fprintf(stderr," Please Try to use a different IP version.\n\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 	}
 
 	if (user_param.work_rdma_cm == OFF) {
 		if (ctx_connect(&ctx,rem_dest,&user_param,my_dest)) {
 			fprintf(stderr," Unable to Connect the HCA's through the link\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 	}
 
@@ -207,7 +217,7 @@ int main(int argc, char *argv[])
 		/* Set up connection one more time to send qpn properly for DC */
 		if (set_up_connection(&ctx,&user_param,my_dest)) {
 			fprintf(stderr," Unable to set up socket connection\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 	}
 
@@ -223,7 +233,7 @@ int main(int argc, char *argv[])
 
 		if (ctx_hand_shake(&user_comm,&my_dest[i],&rem_dest[i])) {
 			fprintf(stderr," Failed to exchange data between server and clients\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 
 		ctx_print_pingpong_data(&rem_dest[i],&user_comm);
@@ -232,14 +242,14 @@ int main(int argc, char *argv[])
 	/* An additional handshake is required after moving qp to RTR. */
 	if (ctx_hand_shake(&user_comm,my_dest,rem_dest)) {
 		fprintf(stderr,"Failed to exchange data between server and clients\n");
-		return FAILURE;
+		goto destroy_context;
 	}
 
 	/* Only Client post read request. */
 	if (user_param.machine == SERVER) {
 		if (ctx_close_connection(&user_comm,my_dest,rem_dest)) {
 			fprintf(stderr,"Failed to close connection between server and client\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 		if (user_param.output == FULL_VERBOSITY) {
 			printf(RESULT_LINE);
@@ -250,8 +260,9 @@ int main(int argc, char *argv[])
 	if (user_param.use_event) {
 		if (ibv_req_notify_cq(ctx.send_cq, 0)) {
 			fprintf(stderr, "Couldn't request CQ notification\n");
-			return FAILURE;
+			goto free_mem;
 		}
+
 	}
 
 	ctx_set_send_wqes(&ctx,&user_param,rem_dest);
@@ -261,19 +272,54 @@ int main(int argc, char *argv[])
 		printf("%s",(user_param.test_type == ITERATIONS) ? RESULT_FMT_LAT : RESULT_FMT_LAT_DUR);
 		printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 	}
-	if(run_iter_lat(&ctx,&user_param))
-		return 17;
+
+	if(run_iter_lat(&ctx,&user_param)){
+		error = 17;
+		goto free_mem;
+	}
 
 	user_param.test_type == ITERATIONS ? print_report_lat(&user_param) : print_report_lat_duration(&user_param);
 
 	if (ctx_close_connection(&user_comm,my_dest,rem_dest)) {
 		fprintf(stderr,"Failed to close connection between server and client\n");
-		return FAILURE;
+		goto free_mem;
 	}
 
 	if (user_param.output == FULL_VERBOSITY) {
 		printf(RESULT_LINE);
 	}
 
-	return 0;
+	if (user_param.work_rdma_cm == ON) {
+		if (destroy_ctx(&ctx, &user_param)) {
+			fprintf(stderr, "Failed to destroy resources.\n");
+			goto destroy_cm_context;
+		}
+
+		user_comm.rdma_params->work_rdma_cm = OFF;
+		free(my_dest);
+		free(rem_dest);
+		return destroy_ctx(user_comm.rdma_ctx, user_comm.rdma_params);
+	}
+
+	free(my_dest);
+	free(rem_dest);
+
+	return destroy_ctx(&ctx, &user_param);
+
+destroy_context:
+	if (destroy_ctx(&ctx,&user_param))
+		fprintf(stderr, "Failed to destroy resources\n");
+destroy_cm_context:
+	if (user_param.work_rdma_cm == ON) {
+		user_comm.rdma_params->work_rdma_cm = OFF;
+		destroy_ctx(user_comm.rdma_ctx,user_comm.rdma_params);
+	}
+free_mem:
+	free(my_dest);
+free_rem_dest:
+	free(rem_dest);
+return_error:
+	return error;
+
 }
+

--- a/src/clock_test.c
+++ b/src/clock_test.c
@@ -7,7 +7,6 @@ int main()
 	int no_cpu_freq_fail = 0;
 	double mhz;
 	mhz = get_cpu_mhz(no_cpu_freq_fail);
-	cycles_t c1, c2;
 
 	if (!mhz) {
 		printf("Unable to calibrate cycles. Exiting.\n");
@@ -16,6 +15,7 @@ int main()
 
 	printf("Type CTRL-C to cancel.\n");
 	for (;;) {
+		cycles_t c1,c2;
 		c1 = get_cycles();
 		sleep(1);
 		c2 = get_cycles();

--- a/src/get_clock.c
+++ b/src/get_clock.c
@@ -65,9 +65,7 @@ http://en.wikipedia.org/wiki/Linear_regression#Parameter_estimation
 static double sample_get_cpu_mhz(void)
 {
 	struct timeval tv1, tv2;
-	cycles_t start;
 	double sx = 0, sy = 0, sxx = 0, syy = 0, sxy = 0;
-	double tx, ty;
 	int i;
 
 	/* Regression: y = a + b x */
@@ -78,7 +76,7 @@ static double sample_get_cpu_mhz(void)
 	double r_2;
 
 	for (i = 0; i < MEASUREMENTS; ++i) {
-		start = get_cycles();
+		cycles_t start = get_cycles();
 
 		if (gettimeofday(&tv1, NULL)) {
 			fprintf(stderr, "gettimeofday failed.\n");
@@ -101,8 +99,8 @@ static double sample_get_cpu_mhz(void)
 	}
 
 	for (i = 0; i < MEASUREMENTS; ++i) {
-		tx = x[i];
-		ty = y[i];
+		double tx = x[i];
+		double ty = y[i];
 		sx += tx;
 		sy += ty;
 		sxx += tx * tx;

--- a/src/multicast_resources.c
+++ b/src/multicast_resources.c
@@ -141,10 +141,10 @@ void set_multicast_gid(struct mcast_parameters *params,uint32_t qp_num,int is_cl
 	uint8_t mcg_gid[16] = MCG_GID;
 	const char *pstr = params->user_mgid;
 	char *term = NULL;
-	char tmp[20];
-	int i;
 
 	if (params->user_mgid) {
+		int i;
+		char tmp[20];
 		term = strpbrk(pstr, ":");
 		memcpy(tmp, pstr, term - pstr+1);
 		tmp[term - pstr] = 0;

--- a/src/perftest_communication.h
+++ b/src/perftest_communication.h
@@ -133,6 +133,18 @@ int create_comm_struct (struct perftest_comm *comm,
 		struct perftest_parameters *user_param);
 
 
+/* dealloc_comm_struct .
+ *
+ * Description : deallocating the already allocated structs in perftest_comm.
+ *
+ * Parameters :
+ *  comm - A Communication struct.
+ *  user_param -  Perftest parameters.
+ */
+void dealloc_comm_struct(struct perftest_comm *comm,
+		struct perftest_parameters *user_param);
+
+
 /* set_up_connection .
  *
  * Description : Fills the my_dest with all of the machine proporties.

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -139,6 +139,7 @@
 #define DEF_INLINE_SEND_XRC (236)
 #define DEF_INLINE_SEND_UD (188)
 #define DEF_INLINE_DC (150)
+#define DEF_INLINE_SEND_RC_UC_XRC (236)
 
 /* AES-XTS Values */
 #define AES_XTS_TWEAK_SIZE (16)
@@ -299,6 +300,16 @@ t_stdev: %.2f,\npercentile_99: %.2f,\npercentile_99.9: %.2f,\n"
 #define ALLOCATE(var,type,size)                                     \
 { if((var = (type*)malloc(sizeof(type)*(size))) == NULL)        \
 	{ fprintf(stderr," Cannot Allocate\n"); exit(1);}}
+
+/* Macro for allocating in alloc_ctx function */
+#define ALLOC(var,type,size)									\
+{ if((var = (type*)malloc(sizeof(type)*(size))) == NULL)        \
+	{ fprintf(stderr," Cannot Allocate\n"); dealloc_ctx(ctx, user_param); return 1;}}
+
+/* Macro for allocating and jump to destroy labels in case of failures */
+#define MAIN_ALLOC(var,type,size,label)									\
+{ if((var = (type*)malloc(sizeof(type)*(size))) == NULL)        \
+	{ fprintf(stderr," Cannot Allocate\n"); goto label;}}
 
 /* This is our string builder */
 #define GET_STRING(orig,temp) 						            \
@@ -601,6 +612,7 @@ struct perftest_parameters {
 	struct counter_context		*counter_ctx;
 	char				*source_ip;
 	int 				has_source_ip;
+	int 			ah_allocated;
 };
 
 struct report_options {

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -314,8 +314,20 @@ int destroy_rdma_resources(struct pingpong_context *ctx,
  * Parameters :
  *	ctx - Resources sructure.
  * 	user_param - the perftest parameters.
+ *
+ * Return Value : SUCCESS, FAILURE.
  */
-void alloc_ctx(struct pingpong_context *ctx,struct perftest_parameters *user_param);
+int alloc_ctx(struct pingpong_context *ctx,struct perftest_parameters *user_param);
+
+/* dealloc_ctx
+ *
+ * Description : Deallocate the perftest allocated arrays only.
+ *
+ * Parameters :
+ *	ctx - Resources sructure.
+ * 	user_param - the perftest parameters.
+ */
+void dealloc_ctx(struct pingpong_context *ctx,struct perftest_parameters *user_param);
 
 /* destroy_ctx
  *

--- a/src/raw_ethernet_send_burst_lat.c
+++ b/src/raw_ethernet_send_burst_lat.c
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
 	struct ibv_flow_attr		**flow_rules;
 	struct ibv_flow 		*flow_promisc = NULL;
 	struct report_options		report;
-	int				i;
+	int				i, flows_created = 0;
 
 	/* allocate memory space for user parameters &*/
 	memset(&ctx,		0, sizeof(struct pingpong_context));
@@ -97,8 +97,8 @@ int main(int argc, char *argv[])
 		DEBUG_LOG(TRACE,"<<<<<<%s",__FUNCTION__);
 		return FAILURE;
 	}
-	ALLOCATE(flow_create_result, struct ibv_flow*, user_param.flows);
-	ALLOCATE(flow_rules, struct ibv_flow_attr*, user_param.flows);
+	MAIN_ALLOC(flow_create_result, struct ibv_flow*, user_param.flows, return_error);
+	MAIN_ALLOC(flow_rules, struct ibv_flow_attr*, user_param.flows, free_flow_results);
 
 
 	/*this is a bidirectional test, so we need to let the init functions
@@ -111,11 +111,11 @@ int main(int argc, char *argv[])
 	if (!ib_dev) {
 		fprintf(stderr," Unable to find the Infiniband/RoCE device\n");
 		DEBUG_LOG(TRACE,"<<<<<<%s",__FUNCTION__);
-		return FAILURE;
+		goto free_mem;
 	}
 
 	if (check_flow_steering_support(user_param.ib_devname)) {
-		return FAILURE;
+		goto free_mem;
 	}
 
 	/* Getting the relevant context from the device */
@@ -123,31 +123,35 @@ int main(int argc, char *argv[])
 	if (!ctx.context) {
 		fprintf(stderr, " Couldn't get context for the device\n");
 		DEBUG_LOG(TRACE,"<<<<<<%s",__FUNCTION__);
-		return FAILURE;
+		goto free_mem;
 	}
 
 	/* Verify user parameters that require the device context,
 	 * the function will print the relevent error info. */
 	if (verify_params_with_device_context(ctx.context, &user_param)) {
-		return FAILURE;
+		goto free_mem;
 	}
 
 	/* See if MTU and link type are valid and supported. */
 	if (check_link_and_mtu(ctx.context, &user_param)) {
 		fprintf(stderr, " Couldn't get context for the device\n");
 		DEBUG_LOG(TRACE,"<<<<<<%s",__FUNCTION__);
-		return FAILURE;
+		goto free_mem;
 	}
 
 	/* Allocating arrays needed for the test. */
-	alloc_ctx(&ctx, &user_param);
+	if (alloc_ctx(&ctx,&user_param)){
+		fprintf(stderr, "Couldn't allocate context\n");
+		goto free_mem;
+	}
 
 	/*set up the connection, return the required flow rules (notice that user_param->duplex == TRUE)
 	 * so the function will setup like it's a bidirectional test
 	 */
 	if (send_set_up_connection(flow_rules, &ctx, &user_param, &my_dest_info, &rem_dest_info)) {
 		fprintf(stderr," Unable to set up socket connection\n");
-		return FAILURE;
+		dealloc_ctx(&ctx, &user_param);
+			goto free_mem;
 	}
 
 	/* Print basic test information. */
@@ -159,7 +163,8 @@ int main(int argc, char *argv[])
 	/* initalize IB resources (data buffer, PD, MR, CQ and events channel) */
 	if (ctx_init(&ctx, &user_param)) {
 		fprintf(stderr, " Couldn't create IB resources\n");
-		return FAILURE;
+		dealloc_ctx(&ctx, &user_param);
+			goto free_mem;
 	}
 
 
@@ -170,8 +175,9 @@ int main(int argc, char *argv[])
 		if (!flow_create_result[i]){
 			perror("error");
 			fprintf(stderr, "Couldn't attach QP\n");
-			return FAILURE;
+			goto result_flow_destroy;
 		}
+		flows_created++;
 	}
 
 	if (user_param.use_promiscuous) {
@@ -185,9 +191,9 @@ int main(int argc, char *argv[])
 		if ((flow_promisc = ibv_create_flow(ctx.qp[0], &attr)) == NULL) {
 			perror("error");
 			fprintf(stderr, "Couldn't attach promiscuous rule QP\n");
+			goto result_flow_destroy;
 		}
 	}
-
 	/* build ONE Raw Ethernet packets on ctx buffer */
 	create_raw_eth_pkt(&user_param, &ctx, (void*)ctx.buf[0], &my_dest_info , &rem_dest_info);
 
@@ -201,24 +207,24 @@ int main(int argc, char *argv[])
 	if (ctx_connect(&ctx, NULL, &user_param, NULL)) {
 		fprintf(stderr," Unable to Connect the HCA's through the link\n");
 		DEBUG_LOG(TRACE,"<<<<<<%s",__FUNCTION__);
-		return FAILURE;
+		goto promisc_flow_destroy;
 	}
 
 	ctx_set_send_wqes(&ctx,&user_param,NULL);
 
 	if (ctx_set_recv_wqes(&ctx,&user_param)) {
 		fprintf(stderr," Failed to post receive recv_wqes\n");
-		return FAILURE;
+		goto free_mem;
 	}
 
 	/* latency test function for SEND verb latency test. */
 	if (user_param.machine == CLIENT) {
 		if (run_iter_lat_burst(&ctx, &user_param))
-			return FAILURE;
+			goto free_mem;
 	}
 	else {
 		if (run_iter_lat_burst_server(&ctx, &user_param))
-			return FAILURE;
+			goto free_mem;
 	}
 
 	/* print report (like print_report_bw) in the correct format
@@ -232,7 +238,7 @@ int main(int argc, char *argv[])
 		if (ibv_destroy_flow(flow_promisc)) {
 			perror("error");
 			fprintf(stderr, "Couldn't destroy promisc flow\n");
-			return FAILURE;
+			goto result_flow_destroy;
 		}
 	}
 
@@ -241,7 +247,7 @@ int main(int argc, char *argv[])
 		if (ibv_destroy_flow(flow_create_result[i])) {
 			perror("error");
 			fprintf(stderr, "Couldn't destroy flow\n");
-			return FAILURE;
+			goto destroy_ctx;
 		}
 
 		free(flow_rules[i]);
@@ -251,12 +257,38 @@ int main(int argc, char *argv[])
 	if (destroy_ctx(&ctx, &user_param)) {
 		fprintf(stderr,"Failed to destroy_ctx\n");
 		DEBUG_LOG(TRACE,"<<<<<<%s",__FUNCTION__);
-		return FAILURE;
+		goto free_mem;
 	}
+
+	free(flow_create_result);
+	free(flow_rules);
 
 	if (user_param.output == FULL_VERBOSITY)
 		printf(RESULT_LINE);
 
 	DEBUG_LOG(TRACE,"<<<<<<%s",__FUNCTION__);
 	return SUCCESS;
+
+promisc_flow_destroy:
+	if (user_param.use_promiscuous) {
+		if (ibv_destroy_flow(flow_promisc)) {
+			perror("error");
+			fprintf(stderr, "Couldn't destroy promisc flow\n");
+		}
+	}
+result_flow_destroy:
+	for (i = 0; i < flows_created; i++) {
+		if (ibv_destroy_flow(flow_create_result[i])) {
+			perror("error");
+			fprintf(stderr, "Couldn't destroy flow\n");
+		}
+	}
+destroy_ctx:
+	destroy_ctx(&ctx, &user_param);
+free_mem:
+	free(flow_rules);
+free_flow_results:
+	free(flow_create_result);
+return_error:
+	return FAILURE;
 }

--- a/src/read_bw.c
+++ b/src/read_bw.c
@@ -47,7 +47,7 @@
  ******************************************************************************/
 int main(int argc, char *argv[])
 {
-	int                        ret_parser, i = 0, rc;
+	int                        ret_parser, i = 0, rc, error = 1;
 	struct ibv_device	   *ib_dev = NULL;
 	struct pingpong_context    ctx;
 	struct pingpong_dest       *my_dest = NULL;
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
 		user_param.num_of_qps *= 2;
 	}
 
-	ib_dev =ctx_find_dev(&user_param.ib_devname);
+	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev)
 		return 7;
 
@@ -114,6 +114,7 @@ int main(int argc, char *argv[])
 	/* Initialize the connection and print the local data. */
 	if (establish_connection(&user_comm)) {
 		fprintf(stderr," Unable to init the socket connection\n");
+		dealloc_comm_struct(&user_comm,&user_param);
 		return FAILURE;
 	}
 
@@ -124,16 +125,21 @@ int main(int argc, char *argv[])
 	/* See if MTU and link type are valid and supported. */
 	if (check_mtu(ctx.context,&user_param, &user_comm)) {
 		fprintf(stderr, " Couldn't get context for the device\n");
+		dealloc_comm_struct(&user_comm,&user_param);
 		return FAILURE;
 	}
 
-	ALLOCATE(my_dest , struct pingpong_dest , user_param.num_of_qps);
+	MAIN_ALLOC(my_dest , struct pingpong_dest , user_param.num_of_qps , return_error);
 	memset(my_dest, 0, sizeof(struct pingpong_dest)*user_param.num_of_qps);
-	ALLOCATE(rem_dest , struct pingpong_dest , user_param.num_of_qps);
+	MAIN_ALLOC(rem_dest , struct pingpong_dest , user_param.num_of_qps , free_my_dest);
 	memset(rem_dest, 0, sizeof(struct pingpong_dest)*user_param.num_of_qps);
 
 	/* Allocating arrays needed for the test. */
-	alloc_ctx(&ctx,&user_param);
+	if (alloc_ctx(&ctx,&user_param)){
+		fprintf(stderr, "Couldn't allocate context\n");
+		dealloc_comm_struct(&user_comm,&user_param);
+		goto free_mem;
+	}
 
 	/* Create RDMA CM resources and connect through CM. */
 	if (user_param.work_rdma_cm == ON) {
@@ -142,31 +148,34 @@ int main(int argc, char *argv[])
 		if (rc) {
 			fprintf(stderr,
 				"Failed to create RDMA CM connection with resources.\n");
-			return FAILURE;
+			dealloc_comm_struct(&user_comm,&user_param);
+			dealloc_ctx(&ctx, &user_param);
+			goto free_mem;
 		}
 	} else {
 		/* create all the basic IB resources. */
 		if (ctx_init(&ctx, &user_param)) {
 			fprintf(stderr, " Couldn't create IB resources\n");
-			return FAILURE;
+			dealloc_comm_struct(&user_comm,&user_param);
+			dealloc_ctx(&ctx, &user_param);
+			goto free_mem;
 		}
 	}
 
 	/* Set up the Connection. */
 	if (set_up_connection(&ctx,&user_param,my_dest)) {
 		fprintf(stderr," Unable to set up socket connection\n");
-		return FAILURE;
+		goto destroy_context;
 	}
 
 	/* Print basic test information. */
 	ctx_print_test_info(&user_param);
-
 	for (i=0; i < user_param.num_of_qps; i++) {
 
 		/* shaking hands and gather the other side info. */
 		if (ctx_hand_shake(&user_comm,&my_dest[i],&rem_dest[i])) {
 			fprintf(stderr,"Failed to exchange data between server and clients\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 	}
 
@@ -174,7 +183,7 @@ int main(int argc, char *argv[])
 		if (ctx_check_gid_compatibility(&my_dest[0], &rem_dest[0])) {
 			fprintf(stderr,"\n Found Incompatibility issue with GID types.\n");
 			fprintf(stderr," Please Try to use a different IP version.\n\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 	}
 
@@ -182,7 +191,7 @@ int main(int argc, char *argv[])
 
 		if (ctx_connect(&ctx,rem_dest,&user_param,my_dest)) {
 			fprintf(stderr," Unable to Connect the HCA's through the link\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 	}
 
@@ -191,7 +200,7 @@ int main(int argc, char *argv[])
 		/* Set up connection one more time to send qpn properly for DC */
 		if (set_up_connection(&ctx,&user_param,my_dest)) {
 			fprintf(stderr," Unable to set up socket connection\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 	}
 
@@ -205,7 +214,7 @@ int main(int argc, char *argv[])
 
 		if (ctx_hand_shake(&user_comm,&my_dest[i],&rem_dest[i])) {
 			fprintf(stderr," Failed to exchange data between server and clients\n");
-			return FAILURE;
+			goto destroy_context;
 		}
 
 		ctx_print_pingpong_data(&rem_dest[i],&user_comm);
@@ -215,7 +224,7 @@ int main(int argc, char *argv[])
 	/* An additional handshake is required after moving qp to RTR. */
 	if (ctx_hand_shake(&user_comm,&my_dest[0],&rem_dest[0])) {
 		fprintf(stderr,"Failed to exchange data between server and clients\n");
-		return FAILURE;
+		goto destroy_context;
 	}
 
 	if (user_param.output == FULL_VERBOSITY) {
@@ -235,7 +244,7 @@ int main(int argc, char *argv[])
 
 		if (ctx_hand_shake(&user_comm,&my_dest[0],&rem_dest[0])) {
 			fprintf(stderr," Failed to exchange data between server and clients\n");
-			return FAILURE;
+			goto free_mem;
 		}
 
 		xchg_bw_reports(&user_comm, &my_bw_rep,&rem_bw_rep,atof(user_param.rem_version));
@@ -243,7 +252,7 @@ int main(int argc, char *argv[])
 
 		if (ctx_close_connection(&user_comm,&my_dest[0],&rem_dest[0])) {
 			fprintf(stderr,"Failed to close connection between server and client\n");
-			return FAILURE;
+			goto free_mem;
 		}
 		if (user_param.output == FULL_VERBOSITY) {
 			if (user_param.report_per_port)
@@ -255,20 +264,23 @@ int main(int argc, char *argv[])
 		if (user_param.work_rdma_cm == ON) {
 			if (destroy_ctx(&ctx,&user_param)) {
 				fprintf(stderr, "Failed to destroy resources\n");
-				return FAILURE;
+				goto destroy_cm_context;
 			}
 
 			user_comm.rdma_params->work_rdma_cm = OFF;
+			free(my_dest);
+			free(rem_dest);
 			return destroy_ctx(user_comm.rdma_ctx,user_comm.rdma_params);
 		}
-
+		free(my_dest);
+		free(rem_dest);
 		return destroy_ctx(&ctx,&user_param);
 	}
 
 	if (user_param.use_event) {
 		if (ibv_req_notify_cq(ctx.send_cq, 0)) {
 			fprintf(stderr, "Couldn't request CQ notification\n");
-			return FAILURE;
+			goto free_mem;
 		}
 	}
 
@@ -282,24 +294,26 @@ int main(int argc, char *argv[])
 			if (user_param.perform_warm_up) {
 				if(perform_warm_up(&ctx, &user_param)) {
 					fprintf(stderr, "Problems with warm up\n");
-					return FAILURE;
+					goto free_mem;
 				}
 			}
 
 			if(user_param.duplex) {
 				if (ctx_hand_shake(&user_comm,&my_dest[0],&rem_dest[0])) {
 					fprintf(stderr,"Failed to sync between server and client between different msg sizes\n");
-					return FAILURE;
+					goto free_mem;
 				}
 			}
 
-			if(run_iter_bw(&ctx,&user_param))
-				return 17;
+			if(run_iter_bw(&ctx,&user_param)) {
+				error = 17;
+				goto free_mem;
+			}
 
 			if (user_param.duplex && (atof(user_param.version) >= 4.6)) {
 				if (ctx_hand_shake(&user_comm,&my_dest[0],&rem_dest[0])) {
 					fprintf(stderr,"Failed to sync between server and client between different msg sizes\n");
-					return FAILURE;
+					goto free_mem;
 				}
 			}
 
@@ -317,20 +331,20 @@ int main(int argc, char *argv[])
 		if (user_param.perform_warm_up) {
 			if(perform_warm_up(&ctx, &user_param)) {
 				fprintf(stderr, "Problems with warm up\n");
-				return FAILURE;
+				goto free_mem;
 			}
 		}
 
 		if(user_param.duplex) {
 			if (ctx_hand_shake(&user_comm,&my_dest[0],&rem_dest[0])) {
 				fprintf(stderr,"Failed to sync between server and client between different msg sizes\n");
-				return FAILURE;
+				goto free_mem;
 			}
 		}
 
 		if(run_iter_bw(&ctx,&user_param)) {
 			fprintf(stderr," Failed to complete run_iter_bw function successfully\n");
-			return FAILURE;
+			goto free_mem;
 		}
 
 		print_report_bw(&user_param,&my_bw_rep);
@@ -361,7 +375,7 @@ int main(int argc, char *argv[])
 
 		if(run_iter_bw_infinitely(&ctx,&user_param)) {
 			fprintf(stderr," Error occurred while running! aborting ...\n");
-			return FAILURE;
+			goto free_mem;
 		}
 	}
 
@@ -377,7 +391,7 @@ int main(int argc, char *argv[])
 
 		if (ctx_hand_shake(&user_comm,&my_dest[0],&rem_dest[0])) {
 			fprintf(stderr," Failed to exchange data between server and clients\n");
-			return FAILURE;
+			goto free_mem;
 		}
 
 		xchg_bw_reports(&user_comm, &my_bw_rep,&rem_bw_rep,atof(user_param.rem_version));
@@ -385,28 +399,48 @@ int main(int argc, char *argv[])
 
 	if (ctx_close_connection(&user_comm,&my_dest[0],&rem_dest[0])) {
 		fprintf(stderr,"Failed to close connection between server and client\n");
-		return FAILURE;
+		goto free_mem;
 	}
 
 	if (!user_param.is_bw_limit_passed && (user_param.is_limit_bw == ON ) ) {
 		fprintf(stderr,"Error: BW result is below bw limit\n");
-		return FAILURE;
+		goto destroy_context;
 	}
 
 	if (!user_param.is_msgrate_limit_passed && (user_param.is_limit_bw == ON )) {
 		fprintf(stderr,"Error: Msg rate  is below msg_rate limit\n");
-		return FAILURE;
+		goto destroy_context;
 	}
 
 	if (user_param.work_rdma_cm == ON) {
 		if (destroy_ctx(&ctx,&user_param)) {
 			fprintf(stderr, "Failed to destroy resources\n");
-			return FAILURE;
+			goto destroy_cm_context;
 		}
 
 		user_comm.rdma_params->work_rdma_cm = OFF;
+		free(rem_dest);
+		free(my_dest);
 		return destroy_ctx(user_comm.rdma_ctx,user_comm.rdma_params);
 	}
 
+	free(rem_dest);
+	free(my_dest);
 	return destroy_ctx(&ctx,&user_param);
+
+
+destroy_context:
+	if (destroy_ctx(&ctx,&user_param))
+		fprintf(stderr, "Failed to destroy resources\n");
+destroy_cm_context:
+	if (user_param.work_rdma_cm == ON) {
+		user_comm.rdma_params->work_rdma_cm = OFF;
+		destroy_ctx(user_comm.rdma_ctx,user_comm.rdma_params);
+	}
+free_mem:
+	free(rem_dest);
+free_my_dest:
+	free(my_dest);
+return_error:
+	return error;
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment-->

Perftest: Introduce fixes for code coverity - cppcheck 
This patchset introduces fixing some warnings generated by cppcheck.
The majority of warnings including memory and resources leaks, type fixes,
duplicate conditions and variables optimizations were solved by code.
In addition, another warnings (mostly false positive) were suppressed by adding comments to the code
--


<!--EndFragment-->
</body>
</html>

