### PR TITLE
Add support for Neuron and HabanaLabs devices

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ AUTOMAKE_OPTIONS= subdir-objects
 
 noinst_LIBRARIES = libperftest.a
 libperftest_a_SOURCES = src/get_clock.c src/perftest_communication.c src/perftest_parameters.c src/perftest_resources.c src/perftest_counters.c src/host_memory.c src/mmap_memory.c
-noinst_HEADERS = src/get_clock.h src/perftest_communication.h src/perftest_parameters.h src/perftest_resources.h src/perftest_counters.h src/memory.h src/host_memory.h src/mmap_memory.h src/cuda_memory.h src/rocm_memory.h
+noinst_HEADERS = src/get_clock.h src/perftest_communication.h src/perftest_parameters.h src/perftest_resources.h src/perftest_counters.h src/memory.h src/host_memory.h src/mmap_memory.h src/cuda_memory.h src/rocm_memory.h src/neuron_memory.h
 
 if CUDA
 libperftest_a_SOURCES += src/cuda_memory.c
@@ -43,6 +43,10 @@ endif
 
 if ROCM
 libperftest_a_SOURCES += src/rocm_memory.c
+endif
+
+if NEURON
+libperftest_a_SOURCES += src/neuron_memory.c
 endif
 
 bin_PROGRAMS = ib_send_bw ib_send_lat ib_write_lat ib_write_bw ib_read_lat ib_read_bw ib_atomic_lat ib_atomic_bw

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,8 +34,16 @@ ACLOCAL_AMFLAGS= -I m4
 AUTOMAKE_OPTIONS= subdir-objects
 
 noinst_LIBRARIES = libperftest.a
-libperftest_a_SOURCES = src/get_clock.c src/perftest_communication.c src/perftest_parameters.c src/perftest_resources.c src/perftest_counters.c
-noinst_HEADERS = src/get_clock.h src/perftest_communication.h src/perftest_parameters.h src/perftest_resources.h src/perftest_counters.h
+libperftest_a_SOURCES = src/get_clock.c src/perftest_communication.c src/perftest_parameters.c src/perftest_resources.c src/perftest_counters.c src/host_memory.c src/mmap_memory.c
+noinst_HEADERS = src/get_clock.h src/perftest_communication.h src/perftest_parameters.h src/perftest_resources.h src/perftest_counters.h src/memory.h src/host_memory.h src/mmap_memory.h src/cuda_memory.h src/rocm_memory.h
+
+if CUDA
+libperftest_a_SOURCES += src/cuda_memory.c
+endif
+
+if ROCM
+libperftest_a_SOURCES += src/rocm_memory.c
+endif
 
 bin_PROGRAMS = ib_send_bw ib_send_lat ib_write_lat ib_write_bw ib_read_lat ib_read_bw ib_atomic_lat ib_atomic_bw
 bin_SCRIPTS = run_perftest_loopback run_perftest_multi_devices

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ AUTOMAKE_OPTIONS= subdir-objects
 
 noinst_LIBRARIES = libperftest.a
 libperftest_a_SOURCES = src/get_clock.c src/perftest_communication.c src/perftest_parameters.c src/perftest_resources.c src/perftest_counters.c src/host_memory.c src/mmap_memory.c
-noinst_HEADERS = src/get_clock.h src/perftest_communication.h src/perftest_parameters.h src/perftest_resources.h src/perftest_counters.h src/memory.h src/host_memory.h src/mmap_memory.h src/cuda_memory.h src/rocm_memory.h src/neuron_memory.h
+noinst_HEADERS = src/get_clock.h src/perftest_communication.h src/perftest_parameters.h src/perftest_resources.h src/perftest_counters.h src/memory.h src/host_memory.h src/mmap_memory.h src/cuda_memory.h src/rocm_memory.h src/neuron_memory.h src/hl_memory.h
 
 if CUDA
 libperftest_a_SOURCES += src/cuda_memory.c
@@ -47,6 +47,10 @@ endif
 
 if NEURON
 libperftest_a_SOURCES += src/neuron_memory.c
+endif
+
+if HABANALABS
+libperftest_a_SOURCES += src/hl_memory.c
 endif
 
 bin_PROGRAMS = ib_send_bw ib_send_lat ib_write_lat ib_write_bw ib_read_lat ib_read_bw ib_atomic_lat ib_atomic_bw

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,11 @@ AC_CHECK_LIB([rdmacm], [rdma_create_event_channel], [], AC_MSG_ERROR([librdmacm-
 AC_CHECK_LIB([ibumad], [umad_init], [LIBUMAD=-libumad], AC_MSG_ERROR([libibumad not found]))
 AC_CHECK_LIB([m], [log], [LIBMATH=-lm], AC_MSG_ERROR([libm not found]))
 
+AC_CHECK_LIB([ibverbs], [ibv_reg_dmabuf_mr], [HAVE_REG_DMABUF_MR=yes], [HAVE_REG_DMABUF_MR=no])
+if test $HAVE_REG_DMABUF_MR = yes; then
+	AC_DEFINE([HAVE_REG_DMABUF_MR], [1], [Enable HAVE_REG_DMABUF_MR])
+fi
+
 AC_TRY_LINK([#include <infiniband/verbs.h>],
 	[struct ibv_flow *t = ibv_create_flow(NULL,NULL);],[HAVE_RAW_ETH_REG=yes], [HAVE_RAW_ETH_REG=no])
 
@@ -259,18 +264,19 @@ fi
 if [test "$CUDA_H_PATH" ]; then
 	AC_DEFINE([HAVE_CUDA], [1], [Enable CUDA feature])
 	AC_DEFINE_UNQUOTED([CUDA_PATH], "$CUDA_H_PATH" , [Enable CUDA feature])
-        LIBS=$LIBS" -lcuda"
-    AC_CHECK_LIB([ibverbs], [ibv_reg_dmabuf_mr], [HAVE_REG_DMABUF_MR=yes], [HAVE_REG_DMABUF_MR=no])
-    AC_CHECK_LIB([cuda], [cuMemGetHandleForAddressRange], [HAVE_CUDA_CUMEMGETHANDLEFORADDRESSRANGE=yes], [HAVE_CUDA_CUMEMGETHANDLEFORADDRESSRANGE=no])
+	LIBS=$LIBS" -lcuda"
+	AC_CHECK_LIB([cuda], [cuMemGetHandleForAddressRange], [HAVE_CUDA_CUMEMGETHANDLEFORADDRESSRANGE=yes], [HAVE_CUDA_CUMEMGETHANDLEFORADDRESSRANGE=no])
 	AC_TRY_LINK([
 	#include <$CUDA_H_PATH>],
-        [int x = CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD|CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED;],
-		[CUDA_DMA_BUF_PARAMETERS_SUPPORT=yes], [CUDA_DMA_BUF_PARAMETERS_SUPPORT=no])
-    if [test "x$HAVE_REG_DMABUF_MR" = "xyes"] && [test "x$HAVE_CUDA_CUMEMGETHANDLEFORADDRESSRANGE" = "xyes"] && [test "x$CUDA_DMA_BUF_PARAMETERS_SUPPORT" = "xyes"]; then
-        AC_DEFINE([HAVE_CUDA_DMABUF], [1], [Enable CUDA DMABUF feature])
-    fi
+	[int x = CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD|CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED;],
+	[CUDA_DMA_BUF_PARAMETERS_SUPPORT=yes], [CUDA_DMA_BUF_PARAMETERS_SUPPORT=no])
+	if [test "x$HAVE_REG_DMABUF_MR" = "xyes"] && [test "x$HAVE_CUDA_CUMEMGETHANDLEFORADDRESSRANGE" = "xyes"] && [test "x$CUDA_DMA_BUF_PARAMETERS_SUPPORT" = "xyes"]; then
+		AC_DEFINE([HAVE_CUDA_DMABUF], [1], [Enable CUDA DMABUF feature])
+	fi
 fi
 AM_CONDITIONAL([CUDA_DMA_BUF_PARAMETERS_SUPPORT],[test "x$CUDA_DMA_BUF_PARAMETERS_SUPPORT" = "xyes"])
+
+AM_CONDITIONAL([CUDA], [test "$CUDA_H_PATH"])
 
 AC_TRY_LINK([#include <infiniband/verbs.h>],
 	[struct ibv_qp_attr *attr; int x = attr->rate_limit;],[HAVE_PACKET_PACING=yes], [HAVE_PACKET_PACING=no])

--- a/configure.ac
+++ b/configure.ac
@@ -278,6 +278,33 @@ AM_CONDITIONAL([CUDA_DMA_BUF_PARAMETERS_SUPPORT],[test "x$CUDA_DMA_BUF_PARAMETER
 
 AM_CONDITIONAL([CUDA], [test "$CUDA_H_PATH"])
 
+AC_ARG_ENABLE([neuron],
+              [AS_HELP_STRING([--enable-neuron],
+                              [Enable Neuron benchmarks])
+              ],
+              [],
+              [enable_neuron=no])
+
+AC_ARG_WITH([neuron],
+            [AS_HELP_STRING([--with-neuron=@<:@NRT installation path@:>@],
+                            [Provide path to NRT installation])
+            ],
+            [AS_CASE([$with_neuron],
+                     [yes|no], [],
+                     [CPPFLAGS="-I$with_neuron/include $CPPFLAGS"
+                      LDFLAGS="-L$with_neuron/lib -Wl,-rpath=$with_neuron/lib $LDFLAGS"])
+            ])
+
+AS_IF([test "x$enable_neuron" = xyes], [
+       AC_DEFINE([HAVE_NEURON], [1], [Enable Neuron benchmarks])
+       AC_CHECK_HEADERS([nrt/nrt.h], [],
+                        [AC_MSG_ERROR([could not find nrt.h in include path])])
+       AC_SEARCH_LIBS([nrt_tensor_allocate], [nrt], [],
+                      [AC_MSG_ERROR([could not find library, nrt])])
+       ])
+
+AM_CONDITIONAL([NEURON], [test x$enable_neuron = xyes])
+
 AC_TRY_LINK([#include <infiniband/verbs.h>],
 	[struct ibv_qp_attr *attr; int x = attr->rate_limit;],[HAVE_PACKET_PACING=yes], [HAVE_PACKET_PACING=no])
 AM_CONDITIONAL([HAVE_PACKET_PACING],[test "x$HAVE_PACKET_PACING" = "xyes"])

--- a/configure.ac
+++ b/configure.ac
@@ -305,6 +305,37 @@ AS_IF([test "x$enable_neuron" = xyes], [
 
 AM_CONDITIONAL([NEURON], [test x$enable_neuron = xyes])
 
+AC_ARG_ENABLE([hl],
+	[AS_HELP_STRING([--enable-hl],
+		[Enable Habana Labs benchmarks])
+	],
+	[],
+	[enable_hl=no])
+
+AC_ARG_WITH([hl],
+	[AS_HELP_STRING([--with-hl=@<:@habanalabs installation prefix@:>@],
+		[Provide Habana Labs installation prefix])
+	],
+	[AS_CASE([$with_hl],
+		[yes|no], [],
+		[CPPFLAGS="-I$with_hl/include/habanalabs $CPPFLAGS"
+		LDFLAGS="-L$with_hl/lib/habanalabs -Wl,-rpath=$with_hl/lib/habanalabs $LDFLAGS"])
+	])
+
+AS_IF([test "x$enable_hl" = xyes], [
+	AC_DEFINE([HAVE_HL], [1], [Enable Habana Labs benchmarks])
+	AS_IF([test "x$HAVE_REG_DMABUF_MR" = "xno"],
+		[AC_MSG_ERROR([rdma-core doesn't support dmabuf mr registration])])
+	AC_CHECK_HEADERS([misc/habanalabs.h hlthunk.h synapse_api.h], [],
+		[AC_MSG_ERROR([could not find hl headers in include path])])
+	AC_SEARCH_LIBS([hlthunk_device_memory_export_dmabuf_fd], [hl-thunk], [],
+		[AC_MSG_ERROR([could not find library, hl-thunk])])
+	AC_SEARCH_LIBS([synDeviceMalloc], [Synapse], [],
+		[AC_MSG_ERROR([could not find library, Synapse])])
+	])
+
+AM_CONDITIONAL([HABANALABS], [test x$enable_hl = xyes])
+
 AC_TRY_LINK([#include <infiniband/verbs.h>],
 	[struct ibv_qp_attr *attr; int x = attr->rate_limit;],[HAVE_PACKET_PACING=yes], [HAVE_PACKET_PACING=no])
 AM_CONDITIONAL([HAVE_PACKET_PACING],[test "x$HAVE_PACKET_PACING" = "xyes"])

--- a/src/cuda_memory.c
+++ b/src/cuda_memory.c
@@ -1,0 +1,249 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "cuda_memory.h"
+#include "perftest_parameters.h"
+#include CUDA_PATH
+
+#define CUCHECK(stmt) \
+	do { \
+	CUresult result = (stmt); \
+	ASSERT(CUDA_SUCCESS == result); \
+} while (0)
+
+#define ACCEL_PAGE_SIZE (64 * 1024)
+
+
+struct cuda_memory_ctx {
+	struct memory_ctx base;
+	int device_id;
+	char *device_bus_id;
+	CUdevice cuDevice;
+	CUcontext cuContext;
+	bool use_dmabuf;
+};
+
+
+static int init_gpu(struct cuda_memory_ctx *ctx)
+{
+	int cuda_device_id = ctx->device_id;
+	int cuda_pci_bus_id;
+	int cuda_pci_device_id;
+	int index;
+	CUdevice cu_device;
+
+	printf("initializing CUDA\n");
+	CUresult error = cuInit(0);
+	if (error != CUDA_SUCCESS) {
+		printf("cuInit(0) returned %d\n", error);
+		return FAILURE;
+	}
+
+	int deviceCount = 0;
+	error = cuDeviceGetCount(&deviceCount);
+	if (error != CUDA_SUCCESS) {
+		printf("cuDeviceGetCount() returned %d\n", error);
+		return FAILURE;
+	}
+	/* This function call returns 0 if there are no CUDA capable devices. */
+	if (deviceCount == 0) {
+		printf("There are no available device(s) that support CUDA\n");
+		return FAILURE;
+	}
+	if (cuda_device_id >= deviceCount) {
+		fprintf(stderr, "No such device ID (%d) exists in system\n", cuda_device_id);
+		return FAILURE;
+	}
+
+	printf("Listing all CUDA devices in system:\n");
+	for (index = 0; index < deviceCount; index++) {
+		CUCHECK(cuDeviceGet(&cu_device, index));
+		cuDeviceGetAttribute(&cuda_pci_bus_id, CU_DEVICE_ATTRIBUTE_PCI_BUS_ID , cu_device);
+		cuDeviceGetAttribute(&cuda_pci_device_id, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID , cu_device);
+		printf("CUDA device %d: PCIe address is %02X:%02X\n", index, (unsigned int)cuda_pci_bus_id, (unsigned int)cuda_pci_device_id);
+	}
+
+	printf("\nPicking device No. %d\n", cuda_device_id);
+
+	CUCHECK(cuDeviceGet(&ctx->cuDevice, cuda_device_id));
+
+	char name[128];
+	CUCHECK(cuDeviceGetName(name, sizeof(name), cuda_device_id));
+	printf("[pid = %d, dev = %d] device name = [%s]\n", getpid(), ctx->cuDevice, name);
+	printf("creating CUDA Ctx\n");
+
+	/* Create context */
+	error = cuCtxCreate(&ctx->cuContext, CU_CTX_MAP_HOST, ctx->cuDevice);
+	if (error != CUDA_SUCCESS) {
+		printf("cuCtxCreate() error=%d\n", error);
+		return FAILURE;
+	}
+
+	printf("making it the current CUDA Ctx\n");
+	error = cuCtxSetCurrent(ctx->cuContext);
+	if (error != CUDA_SUCCESS) {
+		printf("cuCtxSetCurrent() error=%d\n", error);
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+
+static void free_gpu(struct cuda_memory_ctx *ctx)
+{
+	printf("destroying current CUDA Ctx\n");
+	CUCHECK(cuCtxDestroy(ctx->cuContext));
+}
+
+int cuda_memory_init(struct memory_ctx *ctx) {
+	struct cuda_memory_ctx *cuda_ctx = container_of(ctx, struct cuda_memory_ctx, base);
+	int return_value = 0;
+
+	if (cuda_ctx->device_bus_id) {
+		int err;
+
+		printf("initializing CUDA\n");
+		CUresult error = cuInit(0);
+		if (error != CUDA_SUCCESS) {
+			printf("cuInit(0) returned %d\n", error);
+			return FAILURE;
+		}
+
+		printf("Finding PCIe BUS %s\n", cuda_ctx->device_bus_id);
+		err = cuDeviceGetByPCIBusId(&cuda_ctx->device_id, cuda_ctx->device_bus_id);
+		if (err != 0) {
+			fprintf(stderr, "We have an error from cuDeviceGetByPCIBusId: %d\n", err);
+		}
+		printf("Picking GPU number %d\n", cuda_ctx->device_id);
+	}
+
+	return_value = init_gpu(cuda_ctx);
+	if (return_value) {
+		fprintf(stderr, "Couldn't init GPU context: %d\n", return_value);
+		return FAILURE;
+	}
+
+#ifdef HAVE_CUDA_DMABUF
+	if (cuda_ctx->use_dmabuf) {
+		int is_supported = 0;
+
+		CUCHECK(cuDeviceGetAttribute(&is_supported, CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED, cuda_ctx->cuDevice));
+		if (!is_supported) {
+			fprintf(stderr, "DMA-BUF is not supported on this GPU\n");
+			return FAILURE;
+		}
+	}
+#endif
+
+	return SUCCESS;
+}
+
+int cuda_memory_destroy(struct memory_ctx *ctx) {
+	struct cuda_memory_ctx *cuda_ctx = container_of(ctx, struct cuda_memory_ctx, base);
+
+	free_gpu(cuda_ctx);
+	free(cuda_ctx);
+	return SUCCESS;
+}
+
+int cuda_memory_allocate_buffer(struct memory_ctx *ctx, int alignment, uint64_t size, int *dmabuf_fd,
+				uint64_t *dmabuf_offset,  void **addr, bool *can_init) {
+	CUdeviceptr d_A;
+	int error;
+	size_t buf_size = (size + ACCEL_PAGE_SIZE - 1) & ~(ACCEL_PAGE_SIZE - 1);
+
+	printf("cuMemAlloc() of a %lu bytes GPU buffer\n", size);
+
+	error = cuMemAlloc(&d_A, buf_size);
+	if (error != CUDA_SUCCESS) {
+		printf("cuMemAlloc error=%d\n", error);
+		return FAILURE;
+	}
+
+	printf("allocated GPU buffer address at %016llx pointer=%p\n", d_A, (void *)d_A);
+	*addr = (void *)d_A;
+	*can_init = false;
+
+#ifdef HAVE_CUDA_DMABUF
+	{
+		struct cuda_memory_ctx *cuda_ctx = container_of(ctx, struct cuda_memory_ctx, base);
+
+		if (cuda_ctx->use_dmabuf) {
+			CUdeviceptr aligned_ptr;
+			const size_t host_page_size = sysconf(_SC_PAGESIZE);
+			uint64_t offset;
+			size_t aligned_size;
+
+			// Round down to host page size
+			aligned_ptr = d_A & ~(host_page_size - 1);
+			offset = d_A - aligned_ptr;
+			aligned_size = (size + offset + host_page_size - 1) & ~(host_page_size - 1);
+
+			printf("using DMA-BUF for GPU buffer address at %#llx aligned at %#llx with aligned size %zu\n", d_A, aligned_ptr, aligned_size);
+			*dmabuf_fd = 0;
+			error = cuMemGetHandleForAddressRange((void *)dmabuf_fd, aligned_ptr, aligned_size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+			if (error != CUDA_SUCCESS) {
+				printf("cuMemGetHandleForAddressRange error=%d\n", error);
+				return FAILURE;
+			}
+
+			*dmabuf_offset = offset;
+		}
+	}
+#endif
+
+	return SUCCESS;
+}
+
+int cuda_memory_free_buffer(struct memory_ctx *ctx, int dmabuf_fd, void *addr, uint64_t size) {
+	CUdeviceptr d_A = (CUdeviceptr)addr;
+
+	printf("deallocating RX GPU buffer %016llx\n", d_A);
+	cuMemFree(d_A);
+	return SUCCESS;
+}
+
+void *cuda_memory_copy_host_buffer(void *dest, const void *src, size_t size) {
+	cuMemcpy((CUdeviceptr)dest, (CUdeviceptr)src, size);
+	return dest;
+}
+
+void *cuda_memory_copy_buffer_to_buffer(void *dest, const void *src, size_t size) {
+	cuMemcpyDtoD((CUdeviceptr)dest, (CUdeviceptr)src, size);
+	return dest;
+}
+
+bool cuda_memory_supported() {
+	return true;
+}
+
+bool cuda_memory_dmabuf_supported() {
+#ifdef HAVE_CUDA_DMABUF
+	return true;
+#else
+	return false;
+#endif
+}
+
+struct memory_ctx *cuda_memory_create(struct perftest_parameters *params) {
+	struct cuda_memory_ctx *ctx;
+
+	ALLOCATE(ctx, struct cuda_memory_ctx, 1);
+	ctx->base.init = cuda_memory_init;
+	ctx->base.destroy = cuda_memory_destroy;
+	ctx->base.allocate_buffer = cuda_memory_allocate_buffer;
+	ctx->base.free_buffer = cuda_memory_free_buffer;
+	ctx->base.copy_host_to_buffer = cuda_memory_copy_host_buffer;
+	ctx->base.copy_buffer_to_host = cuda_memory_copy_host_buffer;
+	ctx->base.copy_buffer_to_buffer = cuda_memory_copy_buffer_to_buffer;
+	ctx->device_id = params->cuda_device_id;
+	ctx->device_bus_id = params->cuda_device_bus_id;
+	ctx->use_dmabuf = params->use_cuda_dmabuf;
+
+	return &ctx->base;
+}

--- a/src/cuda_memory.h
+++ b/src/cuda_memory.h
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef CUDA_MEMORY_H
+#define CUDA_MEMORY_H
+
+#include "memory.h"
+#include "config.h"
+
+
+struct perftest_parameters;
+
+bool cuda_memory_supported();
+
+bool cuda_memory_dmabuf_supported();
+
+struct memory_ctx *cuda_memory_create(struct perftest_parameters *params);
+
+
+#ifndef HAVE_CUDA
+
+inline bool cuda_memory_supported() {
+	return false;
+}
+
+inline bool cuda_memory_dmabuf_supported() {
+	return false;
+}
+
+inline struct memory_ctx *cuda_memory_create(struct perftest_parameters *params) {
+	return NULL;
+}
+
+#endif
+
+#endif /* CUDA_MEMORY_H */

--- a/src/hl_memory.c
+++ b/src/hl_memory.c
@@ -1,0 +1,116 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "hl_memory.h"
+#include "perftest_parameters.h"
+#include "synapse_api.h"
+#include "hlthunk.h"
+
+#define ACCEL_PAGE_SIZE 4096
+
+
+struct hl_memory_ctx {
+	struct memory_ctx base;
+	char *device_bus_id;
+	synDeviceId device_id;
+	int device_fd;
+};
+
+
+int hl_memory_init(struct memory_ctx *ctx) {
+	struct hl_memory_ctx *hl_ctx = container_of(ctx, struct hl_memory_ctx, base);
+	synStatus status;
+	synDeviceInfo device_info;
+
+	status = synInitialize();
+	if (status != synSuccess) {
+		fprintf(stderr, "Failed to initialize synapse, status %d\n", status);
+		return FAILURE;
+	}
+
+	status = synDeviceAcquire(&hl_ctx->device_id, hl_ctx->device_bus_id);
+	if (status != synSuccess) {
+		fprintf(stderr, "Failed to acquire device, status %d\n", status);
+		return FAILURE;
+	}
+
+	status = synDeviceGetInfo(hl_ctx->device_id, &device_info);
+	if (status != synSuccess) {
+		fprintf(stderr, "Failed to get device info, status %d\n", status);
+		return FAILURE;
+	}
+
+	hl_ctx->device_fd = device_info.fd;
+	return SUCCESS;
+}
+
+int hl_memory_destroy(struct memory_ctx *ctx) {
+	struct hl_memory_ctx *hl_ctx = container_of(ctx, struct hl_memory_ctx, base);
+
+	synDeviceRelease(hl_ctx->device_id);
+	synDestroy();
+
+	free(hl_ctx);
+	return SUCCESS;
+}
+
+int hl_memory_allocate_buffer(struct memory_ctx *ctx, int alignment, uint64_t size, int *dmabuf_fd,
+			      uint64_t *dmabuf_offset, void **addr, bool *can_init) {
+	struct hl_memory_ctx *hl_ctx = container_of(ctx, struct hl_memory_ctx, base);
+	int fd;
+	uint64_t buffer_addr;
+	size_t buf_size = (size + ACCEL_PAGE_SIZE - 1) & ~(ACCEL_PAGE_SIZE - 1);
+	synStatus status = synDeviceMalloc(hl_ctx->device_id, buf_size, 0, 0, &buffer_addr);
+
+	if (status != synSuccess) {
+		fprintf(stderr, "Failed to allocate HL memory on device %d of size %lu\n",
+			hl_ctx->device_id, (unsigned long)buf_size);
+		return FAILURE;
+	}
+
+	fd = hlthunk_device_memory_export_dmabuf_fd(hl_ctx->device_fd, buffer_addr, buf_size, 0);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to export dmabuf. sz[%lu] ptr[%p] err[%d]\n",
+			(unsigned long)buf_size, (void*)buffer_addr, fd);
+		return FAILURE;
+	}
+
+	printf("Allocated %lu bytes of accelerator buffer at %p on fd %d\n",
+	       (unsigned long)buf_size, (void*)buffer_addr, fd);
+	*dmabuf_fd = fd;
+	*dmabuf_offset = 0;
+	*addr = (void*)buffer_addr;
+	*can_init = false;
+	return SUCCESS;
+}
+
+int hl_memory_free_buffer(struct memory_ctx *ctx, int dmabuf_fd, void *addr, uint64_t size) {
+	struct hl_memory_ctx *hl_ctx = container_of(ctx, struct hl_memory_ctx, base);
+
+	synDeviceFree(hl_ctx->device_id, (uint64_t)addr, 0);
+	return SUCCESS;
+}
+
+bool hl_memory_supported() {
+	return true;
+}
+
+struct memory_ctx *hl_memory_create(struct perftest_parameters *params) {
+	struct hl_memory_ctx *ctx;
+
+	ALLOCATE(ctx, struct hl_memory_ctx, 1);
+	ctx->base.init = hl_memory_init;
+	ctx->base.destroy = hl_memory_destroy;
+	ctx->base.allocate_buffer = hl_memory_allocate_buffer;
+	ctx->base.free_buffer = hl_memory_free_buffer;
+	ctx->base.copy_host_to_buffer = memcpy;
+	ctx->base.copy_buffer_to_host = memcpy;
+	ctx->base.copy_buffer_to_buffer = memcpy;
+	ctx->device_bus_id = params->hl_device_bus_id;
+	return &ctx->base;
+}

--- a/src/hl_memory.h
+++ b/src/hl_memory.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef HL_MEMORY_H
+#define HL_MEMORY_H
+
+#include "memory.h"
+#include "config.h"
+
+
+struct perftest_parameters;
+
+bool hl_memory_supported();
+
+struct memory_ctx *hl_memory_create(struct perftest_parameters *params);
+
+
+#ifndef HAVE_HL
+
+inline bool hl_memory_supported() {
+	return false;
+}
+
+inline struct memory_ctx *hl_memory_create(struct perftest_parameters *params) {
+	return NULL;
+}
+
+#endif
+
+#endif /* HL_MEMORY_H */

--- a/src/host_memory.c
+++ b/src/host_memory.c
@@ -1,0 +1,118 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include "host_memory.h"
+#include "perftest_parameters.h"
+
+
+struct host_memory_ctx {
+	struct memory_ctx base;
+	int use_hugepages;
+};
+
+
+#define HUGEPAGE_ALIGN  (2*1024*1024)
+#define SHMAT_ADDR (void *)(0x0UL)
+#define SHMAT_FLAGS (0)
+#define SHMAT_INVALID_PTR ((void *)-1)
+
+#if !defined(__FreeBSD__)
+int alloc_hugepage_region(int alignment, uint64_t size, void **addr)
+{
+	int huge_shmid;
+	uint64_t buf_size;
+	uint64_t buf_alignment = (((alignment + HUGEPAGE_ALIGN -1) / HUGEPAGE_ALIGN) * HUGEPAGE_ALIGN);
+	buf_size = (((size + buf_alignment -1 ) / buf_alignment ) * buf_alignment);
+
+	/* create hugepage shared region */
+	huge_shmid = shmget(IPC_PRIVATE, buf_size, SHM_HUGETLB | IPC_CREAT | SHM_R | SHM_W);
+	if (huge_shmid < 0) {
+		fprintf(stderr, "Failed to allocate hugepages. Please configure hugepages\n");
+		return FAILURE;
+	}
+
+	/* attach shared memory */
+	*addr = (void *)shmat(huge_shmid, SHMAT_ADDR, SHMAT_FLAGS);
+	if (*addr == SHMAT_INVALID_PTR) {
+		fprintf(stderr, "Failed to attach shared memory region\n");
+		return FAILURE;
+	}
+
+	/* Mark shmem for removal */
+	if (shmctl(huge_shmid, IPC_RMID, 0) != 0) {
+		fprintf(stderr, "Failed to mark shm for removal\n");
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+#endif
+
+int host_memory_init(struct memory_ctx *ctx) {
+	return SUCCESS;
+}
+
+int host_memory_destroy(struct memory_ctx *ctx) {
+	struct host_memory_ctx *host_ctx = container_of(ctx, struct host_memory_ctx, base);
+
+	free(host_ctx);
+	return SUCCESS;
+}
+
+int host_memory_allocate_buffer(struct memory_ctx *ctx, int alignment, uint64_t size, int *dmabuf_fd,
+				uint64_t *dmabuf_offset, void **addr, bool *can_init) {
+#if defined(__FreeBSD__)
+	posix_memalign(addr, alignment, size);
+#else
+	struct host_memory_ctx *host_ctx = container_of(ctx, struct host_memory_ctx, base);
+	if (host_ctx->use_hugepages) {
+		if (alloc_hugepage_region(alignment, size, addr) != 0){
+			fprintf(stderr, "Failed to allocate hugepage region.\n");
+			return FAILURE;
+		}
+	} else {
+		*addr = memalign(alignment, size);
+	}
+#endif
+	if (!*addr) {
+		fprintf(stderr, "Couldn't allocate work buf.\n");
+		return FAILURE;
+	}
+
+	memset(*addr, 0, size);
+	*can_init = true;
+	return SUCCESS;
+}
+
+int host_memory_free_buffer(struct memory_ctx *ctx, int dmabuf_fd, void *addr, uint64_t size) {
+	struct host_memory_ctx *host_ctx = container_of(ctx, struct host_memory_ctx, base);
+
+	if (host_ctx->use_hugepages) {
+		shmdt(addr);
+	} else {
+		free(addr);
+	}
+	return SUCCESS;
+}
+
+struct memory_ctx *host_memory_create(struct perftest_parameters *params) {
+	struct host_memory_ctx *ctx;
+
+	ALLOCATE(ctx, struct host_memory_ctx, 1);
+	ctx->base.init = host_memory_init;
+	ctx->base.destroy = host_memory_destroy;
+	ctx->base.allocate_buffer = host_memory_allocate_buffer;
+	ctx->base.free_buffer = host_memory_free_buffer;
+	ctx->base.copy_host_to_buffer = memcpy;
+	ctx->base.copy_buffer_to_host = memcpy;
+	ctx->base.copy_buffer_to_buffer = memcpy;
+	ctx->use_hugepages = params->use_hugepages;
+	return &ctx->base;
+}

--- a/src/host_memory.h
+++ b/src/host_memory.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef HOST_MEMORY_H
+#define HOST_MEMORY_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "memory.h"
+
+
+struct perftest_parameters;
+
+struct memory_ctx *host_memory_create(struct perftest_parameters *params);
+
+#endif /* HOST_MEMORY_H */

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef MEMORY_H
+#define MEMORY_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Get pointer to containing type object by a pointer to its member field */
+#define container_of(ptr, type, member) ({                      \
+                const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
+                (type *)( (char *)__mptr - offsetof(type,member) );})
+
+
+/* Base context for memory management to be extended by concrete implementations */
+struct memory_ctx {
+	int (*init)(struct memory_ctx *ctx);
+	int (*destroy)(struct memory_ctx *ctx);
+	int (*allocate_buffer)(struct memory_ctx *ctx, int alignment, uint64_t size, int *dmabuf_fd,
+			       uint64_t *dmabuf_offset, void **addr, bool *can_init);
+	int (*free_buffer)(struct memory_ctx *ctx, int dmabuf_fd, void *addr, uint64_t size);
+	void *(*copy_host_to_buffer)(void *dest, const void *src, size_t size);
+	void *(*copy_buffer_to_host)(void *dest, const void *src, size_t size);
+	void *(*copy_buffer_to_buffer)(void *dest, const void *src, size_t size);
+};
+
+#endif /* MEMORY_H */

--- a/src/mmap_memory.c
+++ b/src/mmap_memory.c
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <sys/mman.h>
+#include "mmap_memory.h"
+#include "perftest_parameters.h"
+
+
+struct mmap_memory_ctx {
+	struct memory_ctx base;
+	char *file;
+	unsigned long offset;
+};
+
+
+static int init_mmap(void **addr, size_t size, const char *fname, unsigned long offset) {
+	int fd = open(fname, O_RDWR);
+
+	if (fd < 0) {
+		printf("Unable to open '%s': %s\n", fname, strerror(errno));
+		return FAILURE;
+	}
+
+	*addr = mmap(NULL, size, PROT_WRITE | PROT_READ, MAP_SHARED, fd, offset);
+	close(fd);
+
+	if (*addr == MAP_FAILED) {
+		printf("Unable to mmap '%s': %s\n", fname, strerror(errno));
+		return FAILURE;
+	}
+
+	printf("allocated mmap buffer of size %zu at %p\n", size, *addr);
+
+	return SUCCESS;
+}
+
+int mmap_memory_init(struct memory_ctx *ctx) {
+	return SUCCESS;
+}
+
+int mmap_memory_destroy(struct memory_ctx *ctx) {
+	struct mmap_memory_ctx *mmap_ctx = container_of(ctx, struct mmap_memory_ctx, base);
+
+	free(mmap_ctx);
+	return SUCCESS;
+}
+
+int mmap_memory_allocate_buffer(struct memory_ctx *ctx, int alignment, uint64_t size, int *dmabuf_fd,
+				uint64_t *dmabuf_offset, void **addr, bool *can_init) {
+	struct mmap_memory_ctx *mmap_ctx = container_of(ctx, struct mmap_memory_ctx, base);
+
+	if (init_mmap(addr, size, mmap_ctx->file, mmap_ctx->offset))
+	{
+		fprintf(stderr, "Couldn't allocate work buf.\n");
+		return FAILURE;
+	}
+	*can_init = true;
+	return SUCCESS;
+}
+
+int mmap_memory_free_buffer(struct memory_ctx *ctx, int dmabuf_fd, void *addr, uint64_t size) {
+	munmap(addr, size);
+	return SUCCESS;
+}
+
+struct memory_ctx *mmap_memory_create(struct perftest_parameters *params) {
+	struct mmap_memory_ctx *ctx;
+
+	ALLOCATE(ctx, struct mmap_memory_ctx, 1);
+	ctx->base.init = mmap_memory_init;
+	ctx->base.destroy = mmap_memory_destroy;
+	ctx->base.allocate_buffer = mmap_memory_allocate_buffer;
+	ctx->base.free_buffer = mmap_memory_free_buffer;
+	ctx->base.copy_host_to_buffer = memcpy;
+	ctx->base.copy_buffer_to_host = memcpy;
+	ctx->base.copy_buffer_to_buffer = memcpy;
+	ctx->file = params->mmap_file;
+	ctx->offset = params->mmap_offset;
+	return &ctx->base;
+}

--- a/src/mmap_memory.h
+++ b/src/mmap_memory.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef MMAP_MEMORY_H
+#define MMAP_MEMORY_H
+
+#include "memory.h"
+
+
+struct perftest_parameters;
+
+struct memory_ctx *mmap_memory_create(struct perftest_parameters *params);
+
+#endif /* MMAP_MEMORY_H */

--- a/src/neuron_memory.c
+++ b/src/neuron_memory.c
@@ -1,0 +1,124 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <nrt/nrt.h>
+#include "neuron_memory.h"
+#include "perftest_parameters.h"
+
+#define NRT_VISIBLE_CORES_STR_LEN 8
+#define ACCEL_PAGE_SIZE (4 * 1024)
+
+
+struct neuron_memory_ctx {
+	struct memory_ctx base;
+	int core_id;
+	int max_tensors;
+	nrt_tensor_t **tensors;
+	int num_of_tensors;
+};
+
+
+int neuron_memory_init(struct memory_ctx *ctx) {
+	struct neuron_memory_ctx *neuron_ctx = container_of(ctx, struct neuron_memory_ctx, base);
+	NRT_STATUS result;
+	char *env_var = getenv("NEURON_RT_VISIBLE_CORES");
+
+	if (env_var != NULL) {
+		printf("NEURON_RT_VISIBLE_CORES is set to %s, core id will be used relatively\n",env_var);
+	} else {
+		char nrt_visible_cores[NRT_VISIBLE_CORES_STR_LEN];
+
+		printf("NEURON_RT_VISIBLE_CORES is not set, setting to %d\n",neuron_ctx->core_id);
+		snprintf(nrt_visible_cores, sizeof(nrt_visible_cores), "%d", neuron_ctx->core_id);
+		setenv("NEURON_RT_VISIBLE_CORES", nrt_visible_cores, 1);
+		neuron_ctx->core_id = 0;
+	}
+
+	result = nrt_init(NRT_FRAMEWORK_TYPE_NO_FW, "", "");
+	if (result != NRT_SUCCESS) {
+		fprintf(stderr, "Couldn't initialize Neuron device\n");
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+
+int neuron_memory_destroy(struct memory_ctx *ctx) {
+	struct neuron_memory_ctx *neuron_ctx = container_of(ctx, struct neuron_memory_ctx, base);
+	int i;
+
+	for (i = 0; i < neuron_ctx->num_of_tensors; i++) {
+		nrt_tensor_free(&neuron_ctx->tensors[i]);
+	}
+	neuron_ctx->num_of_tensors = 0;
+	nrt_close();
+
+	free(neuron_ctx->tensors);
+	free(neuron_ctx);
+	return SUCCESS;
+}
+
+int neuron_memory_allocate_buffer(struct memory_ctx *ctx, int alignment, uint64_t size, int *dmabuf_fd,
+				  uint64_t *dmabuf_offset, void **addr, bool *can_init) {
+	struct neuron_memory_ctx *neuron_ctx = container_of(ctx, struct neuron_memory_ctx, base);
+	void *d_A = NULL;
+	NRT_STATUS result;
+	size_t buf_size = (size + ACCEL_PAGE_SIZE - 1) & ~(ACCEL_PAGE_SIZE - 1);
+	int tensor_index = neuron_ctx->num_of_tensors;
+
+	if (tensor_index >= neuron_ctx->max_tensors)
+	{
+		printf("Can't allocate Neuron memory, max tensors reached\n");
+		return FAILURE;
+	}
+
+	result = nrt_tensor_allocate(NRT_TENSOR_PLACEMENT_DEVICE, neuron_ctx->core_id, buf_size, NULL, &neuron_ctx->tensors[tensor_index]);
+	if (result != NRT_SUCCESS) {
+		neuron_ctx->tensors[tensor_index] = NULL;
+		printf("nrt_tensor_allocate_error =%d\n", (int)result);
+		return FAILURE;
+	}
+
+	d_A = nrt_tensor_get_va(neuron_ctx->tensors[tensor_index]);
+	if (d_A == NULL) {
+		nrt_tensor_free(&neuron_ctx->tensors[tensor_index]);
+		neuron_ctx->tensors[tensor_index] = NULL;
+		printf("Failed to get va for the allocated tensor\n");
+		return FAILURE;
+	}
+
+	neuron_ctx->num_of_tensors++;
+	*addr = d_A;
+	*can_init = false;
+	return SUCCESS;
+}
+
+int neuron_memory_free_buffer(struct memory_ctx *ctx, int dmabuf_fd, void *addr, uint64_t size) {
+	return SUCCESS;
+}
+
+bool neuron_memory_supported() {
+	return true;
+}
+
+struct memory_ctx *neuron_memory_create(struct perftest_parameters *params) {
+	struct neuron_memory_ctx *ctx;
+
+	ALLOCATE(ctx, struct neuron_memory_ctx, 1);
+	ctx->base.init = neuron_memory_init;
+	ctx->base.destroy = neuron_memory_destroy;
+	ctx->base.allocate_buffer = neuron_memory_allocate_buffer;
+	ctx->base.free_buffer = neuron_memory_free_buffer;
+	ctx->base.copy_host_to_buffer = memcpy;
+	ctx->base.copy_buffer_to_host = memcpy;
+	ctx->base.copy_buffer_to_buffer = memcpy;
+	ctx->core_id = params->neuron_core_id;
+	ctx->max_tensors = params->num_of_qps * 2;
+	ALLOCATE(ctx->tensors, nrt_tensor_t* , ctx->max_tensors);
+	ctx->num_of_tensors = 0;
+	return &ctx->base;
+}

--- a/src/neuron_memory.h
+++ b/src/neuron_memory.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NEURON_MEMORY_H
+#define NEURON_MEMORY_H
+
+#include "memory.h"
+#include "config.h"
+
+
+struct perftest_parameters;
+
+bool neuron_memory_supported();
+
+struct memory_ctx *neuron_memory_create(struct perftest_parameters *params);
+
+
+#ifndef HAVE_NEURON
+
+inline bool neuron_memory_supported() {
+	return false;
+}
+
+inline struct memory_ctx *neuron_memory_create(struct perftest_parameters *params) {
+	return NULL;
+}
+
+#endif
+
+#endif /* NEURON_MEMORY_H */

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -438,7 +438,8 @@ enum memory_type {
 	MEMORY_MMAP,
 	MEMORY_CUDA,
 	MEMORY_ROCM,
-	MEMORY_NEURON
+	MEMORY_NEURON,
+	MEMORY_HL
 };
 
 struct perftest_parameters {
@@ -567,6 +568,7 @@ struct perftest_parameters {
 	int				use_cuda_dmabuf;
 	int				rocm_device_id;
 	int				neuron_core_id;
+	char				*hl_device_bus_id;
 	char				*mmap_file;
 	unsigned long			mmap_offset;
 	/* New test params format pilot. will be used in all flags soon,. */

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -437,7 +437,8 @@ enum memory_type {
 	MEMORY_HOST,
 	MEMORY_MMAP,
 	MEMORY_CUDA,
-	MEMORY_ROCM
+	MEMORY_ROCM,
+	MEMORY_NEURON
 };
 
 struct perftest_parameters {
@@ -565,6 +566,7 @@ struct perftest_parameters {
 	char				*cuda_device_bus_id;
 	int				use_cuda_dmabuf;
 	int				rocm_device_id;
+	int				neuron_core_id;
 	char				*mmap_file;
 	unsigned long			mmap_offset;
 	/* New test params format pilot. will be used in all flags soon,. */

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -172,12 +172,6 @@ struct pingpong_context {
 	struct ibv_cq				*send_cq;
 	struct ibv_cq				*recv_cq;
 	void					**buf;
-	#ifdef HAVE_CUDA
-	#ifdef HAVE_CUDA_DMABUF
-	int					*cuda_buf_dmabuf_fd;
-	uint64_t				*cuda_buf_dmabuf_offset;
-	#endif
-	#endif
 	struct ibv_ah				**ah;
 	struct ibv_qp				**qp;
 	#ifdef HAVE_IBV_WR_API
@@ -202,7 +196,6 @@ struct pingpong_context {
 	uint64_t				send_qp_buff_size;
 	uint64_t				flow_buff_size;
 	int					tx_depth;
-	int					huge_shmid;
 	uint64_t				*scnt;
 	uint64_t				*ccnt;
 	int					is_contig_supported;
@@ -223,6 +216,7 @@ struct pingpong_context {
 	struct ibv_xrcd				*xrc_domain;
 	int 					fd;
 	#endif
+	struct memory_ctx			*memory;
 };
 
  struct pingpong_dest {

--- a/src/raw_ethernet_resources.h
+++ b/src/raw_ethernet_resources.h
@@ -158,15 +158,15 @@ struct TCP_header {
 	uint16_t        th_urgptr;
 }__attribute__((packed));
 
-void gen_eth_header(struct ETH_header* eth_header,uint8_t* src_mac,uint8_t* dst_mac, uint16_t eth_type, struct perftest_parameters* user_param);
+void gen_eth_header(struct ETH_header* eth_header,uint8_t* src_mac,uint8_t* dst_mac, uint16_t eth_type, struct perftest_parameters* user_param, struct memory_ctx* memory);
 void print_spec(struct ibv_flow_attr* flow_rules,struct perftest_parameters* user_param);
 //void print_ethernet_header(struct ETH_header* p_ethernet_header);
-void print_ethernet_header(void* p_ethernet_header, struct perftest_parameters* user_param);
+void print_ethernet_header(void* p_ethernet_header, struct perftest_parameters* user_param, struct memory_ctx *memory);
 //void print_ethernet_vlan_header(struct ETH_vlan_header* p_ethernet_header);
-void print_ethernet_vlan_header(void* p_ethernet_header, struct perftest_parameters* user_param);
+void print_ethernet_vlan_header(void* p_ethernet_header, struct perftest_parameters* user_param, struct memory_ctx *memory);
 void print_ip_header(struct IP_V4_header* ip_header);
 void print_udp_header(struct UDP_header* udp_header);
-void print_pkt(void* pkt,struct perftest_parameters *user_param);
+void print_pkt(void* pkt,struct perftest_parameters *user_param, struct memory_ctx *memory);
 
 int check_flow_steering_support(char *dev_name);
 
@@ -188,6 +188,7 @@ void build_pkt_on_buffer(struct ETH_header* eth_header,
 		struct raw_ethernet_info *my_dest_info,
 		struct raw_ethernet_info *rem_dest_info,
 		struct perftest_parameters *user_param,
+		struct memory_ctx *memory,
 		uint16_t eth_type,
 		uint16_t ip_next_protocol,
 		int print_flag,

--- a/src/rocm_memory.c
+++ b/src/rocm_memory.c
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <hip/hip_runtime_api.h>
+#include "rocm_memory.h"
+#include "perftest_parameters.h"
+
+#define ROCM_CHECK(stmt)			\
+	do {					\
+	hipError_t result = (stmt);		\
+	ASSERT(hipSuccess == result);		\
+} while (0)
+
+#define ACCEL_PAGE_SIZE (64 * 1024)
+
+
+struct rocm_memory_ctx {
+	struct memory_ctx base;
+	int device_id;
+};
+
+
+static int init_rocm(int device_id) {
+	int deviceCount = 0;
+	hipError_t error = hipGetDeviceCount(&deviceCount);
+
+	if (error != hipSuccess) {
+		printf("hipDeviceGetCount() returned %d\n", error);
+		return FAILURE;
+	}
+
+	if (device_id >= deviceCount) {
+		printf("Requested ROCm device %d but found only %d device(s)\n",
+               device_id, deviceCount);
+		return FAILURE;
+	}
+
+	ROCM_CHECK(hipSetDevice(device_id));
+
+	hipDeviceProp_t prop = {0};
+	ROCM_CHECK(hipGetDeviceProperties(&prop, device_id));
+	printf("Using ROCm Device with ID: %d, Name: %s, PCI Bus ID: 0x%x, GCN Arch: %d\n",
+	       device_id, prop.name, prop.pciBusID, prop.gcnArch);
+
+	return SUCCESS;
+}
+
+int rocm_memory_init(struct memory_ctx *ctx) {
+	struct rocm_memory_ctx *rocm_ctx = container_of(ctx, struct rocm_memory_ctx, base);
+
+	if (init_rocm(rocm_ctx->device_id)) {
+		fprintf(stderr, "Couldn't initialize ROCm device\n");
+		return FAILURE;
+	}
+	return SUCCESS;
+}
+
+int rocm_memory_destroy(struct memory_ctx *ctx) {
+	struct rocm_memory_ctx *rocm_ctx = container_of(ctx, struct rocm_memory_ctx, base);
+
+	free(rocm_ctx);
+	return SUCCESS;
+}
+
+int rocm_memory_allocate_buffer(struct memory_ctx *ctx, int alignment, uint64_t size, int *dmabuf_fd,
+				uint64_t *dmabuf_offset, void **addr, bool *can_init) {
+	void *d_A;
+	hipError_t error;
+	size_t buf_size = (size + ACCEL_PAGE_SIZE - 1) & ~(ACCEL_PAGE_SIZE - 1);
+
+	error = hipMalloc(&d_A, buf_size);
+	if (error != hipSuccess) {
+		printf("hipMalloc error=%d\n", error);
+		return FAILURE;
+	}
+
+	printf("allocated %lu bytes of GPU buffer at %p\n", (unsigned long)buf_size, d_A);
+	*addr = d_A;
+	*can_init = true;
+	return SUCCESS;
+}
+
+int rocm_memory_free_buffer(struct memory_ctx *ctx, int dmabuf_fd, void *addr, uint64_t size) {
+	printf("deallocating GPU buffer %p\n", addr);
+	hipFree(addr);
+	return SUCCESS;
+}
+
+bool rocm_memory_supported() {
+	return true;
+}
+
+struct memory_ctx *rocm_memory_create(struct perftest_parameters *params) {
+	struct rocm_memory_ctx *ctx;
+
+	ALLOCATE(ctx, struct rocm_memory_ctx, 1);
+	ctx->base.init = rocm_memory_init;
+	ctx->base.destroy = rocm_memory_destroy;
+	ctx->base.allocate_buffer = rocm_memory_allocate_buffer;
+	ctx->base.free_buffer = rocm_memory_free_buffer;
+	ctx->base.copy_host_to_buffer = memcpy;
+	ctx->base.copy_buffer_to_host = memcpy;
+	ctx->base.copy_buffer_to_buffer = memcpy;
+	ctx->device_id = params->rocm_device_id;
+
+	return &ctx->base;
+}

--- a/src/rocm_memory.h
+++ b/src/rocm_memory.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef ROCM_MEMORY_H
+#define ROCM_MEMORY_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "memory.h"
+#include "config.h"
+
+
+struct perftest_parameters;
+
+bool rocm_memory_supported();
+
+struct memory_ctx *rocm_memory_create(struct perftest_parameters *params);
+
+
+#ifndef HAVE_ROCM
+
+inline bool rocm_memory_supported() {
+	return false;
+}
+
+inline struct memory_ctx *rocm_memory_create(struct perftest_parameters *params) {
+	return NULL;
+}
+
+#endif
+
+#endif /* ROCM_MEMORY_H */


### PR DESCRIPTION
This PR adds abstraction layer for supporting various AI HW accelerators.

Add support for Neuron accelerator device memory usage.
To support Neuron, configure using  --enable-neuron --with-neuron=<path/to/neuron/base>.
Run bandwidth tests with Neuron direct by specifying --use_neuron <logical neuron core id> option.

Add support for Habana Labs accelerators device memory usage.
To support Habana Labs, configure using --enable-hl --with-hl=<habanalabs/installation/prefix>
Run bandwidth tests with Habana Labs direct by specifying --use_hl <pci_bus_id>.