### PR TITLE
perftest_parameters: Enable RDMA atomic with ODP feature

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1319,12 +1319,6 @@ static void force_dependecies(struct perftest_parameters *user_param)
 		}
 	}
 
-	if(user_param->connection_type == UC && user_param->use_odp) {
-		printf(RESULT_LINE);
-		fprintf(stderr," ODP does not support UC\n");
-		exit(1);
-	}
-
 	if (user_param->verb == SEND && user_param->tst == BW && user_param->machine == SERVER && !user_param->duplex )
 		user_param->noPeak = ON;
 

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1319,12 +1319,6 @@ static void force_dependecies(struct perftest_parameters *user_param)
 		}
 	}
 
-	if(user_param->verb == ATOMIC && user_param->use_odp) {
-		printf(RESULT_LINE);
-		fprintf(stderr," ODP does not support ATOMICS for now\n");
-		exit(1);
-	}
-
 	if(user_param->connection_type == UC && user_param->use_odp) {
 		printf(RESULT_LINE);
 		fprintf(stderr," ODP does not support UC\n");

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1569,17 +1569,23 @@ int destroy_ctx(struct pingpong_context *ctx,
 static int check_odp_support(struct pingpong_context *ctx)
 {
 	struct ibv_device_attr_ex dattr;
-	int odp_support_send = IBV_ODP_SUPPORT_SEND;
-	int odp_support_recv = IBV_ODP_SUPPORT_RECV;
 	int ret = ibv_query_device_ex(ctx->context, NULL, &dattr);
 
 	if (ret) {
 		fprintf(stderr, " Couldn't query device for on-demand paging capabilities.\n");
 		return 0;
-	} else if (!(dattr.odp_caps.per_transport_caps.rc_odp_caps & odp_support_send)) {
+	}
+
+	/* These capabilities must be set by device drivers. */
+	if (!(dattr.odp_caps.general_caps & IBV_ODP_SUPPORT)) {
+		fprintf(stderr, " The device does not support On-Demand Paging.\n");
+                return 0;
+        }
+
+	if (!(dattr.odp_caps.per_transport_caps.rc_odp_caps & IBV_ODP_SUPPORT_SEND)) {
 		fprintf(stderr, " Send is not supported for RC transport.\n");
 		return 0;
-	} else if (!(dattr.odp_caps.per_transport_caps.rc_odp_caps & odp_support_recv)) {
+	} else if (!(dattr.odp_caps.per_transport_caps.rc_odp_caps & IBV_ODP_SUPPORT_RECV)) {
 		fprintf(stderr, " Receive is not supported for RC transport.\n");
 		return 0;
 	}

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1566,29 +1566,102 @@ int destroy_ctx(struct pingpong_context *ctx,
  *
  ******************************************************************************/
 #ifdef HAVE_EX_ODP
-static int check_odp_support(struct pingpong_context *ctx)
+static int check_odp_transport_caps(struct perftest_parameters *user_param, uint32_t caps)
+{
+	static char conn_str[][7] = {"RC", "UC", "UD", "RawEth", "XRC", "DC", "SRD"};
+	int conn = user_param->connection_type;
+	VerbType verb = user_param->verb;
+	MachineType machine = user_param->machine;
+	int duplex = user_param->duplex;
+
+	if (verb == SEND && duplex == OFF && machine == CLIENT) {
+		if (!(caps & IBV_ODP_SUPPORT_SEND)) {
+			fprintf(stderr, " ODP Send is not supported for %s transport.\n", conn_str[conn]);
+			return 0;
+		}
+	} else if (verb == SEND && duplex == OFF && machine == SERVER) {
+		if (!(caps & (IBV_ODP_SUPPORT_RECV | IBV_ODP_SUPPORT_SRQ_RECV))) {
+			fprintf(stderr, " ODP Recv is not supported for %s transport.\n", conn_str[conn]);
+			return 0;
+		}
+	} else if (verb == SEND && duplex == ON) {
+		if (!(caps & IBV_ODP_SUPPORT_SEND &&
+		      caps & (IBV_ODP_SUPPORT_RECV | IBV_ODP_SUPPORT_SRQ_RECV))) {
+			fprintf(stderr, " ODP bidirectional Send is not supported for %s transport.\n", conn_str[conn]);
+			return 0;
+		}
+	} else if (verb == WRITE && !(caps & IBV_ODP_SUPPORT_WRITE)) {
+		fprintf(stderr, " ODP Write is not supported for %s transport.\n", conn_str[conn]);
+		return 0;
+	} else if (verb == READ && !(caps & IBV_ODP_SUPPORT_READ)) {
+		fprintf(stderr, " ODP Read is not supported for %s transport.\n", conn_str[conn]);
+		return 0;
+	} else if (verb == ATOMIC && !(caps & IBV_ODP_SUPPORT_ATOMIC)) {
+		fprintf(stderr, " ODP Atomics are not supported for %s transport.\n", conn_str[conn]);
+		return 0;
+	}
+
+	return 1;
+}
+
+static int check_odp_support(struct pingpong_context *ctx, struct perftest_parameters *user_param)
 {
 	struct ibv_device_attr_ex dattr;
+	int conn = user_param->connection_type;
 	int ret = ibv_query_device_ex(ctx->context, NULL, &dattr);
 
 	if (ret) {
-		fprintf(stderr, " Couldn't query device for on-demand paging capabilities.\n");
+		fprintf(stderr, " Couldn't query device for On-Demand Paging capabilities.\n");
 		return 0;
 	}
 
 	/* These capabilities must be set by device drivers. */
 	if (!(dattr.odp_caps.general_caps & IBV_ODP_SUPPORT)) {
 		fprintf(stderr, " The device does not support On-Demand Paging.\n");
-                return 0;
-        }
-
-	if (!(dattr.odp_caps.per_transport_caps.rc_odp_caps & IBV_ODP_SUPPORT_SEND)) {
-		fprintf(stderr, " Send is not supported for RC transport.\n");
-		return 0;
-	} else if (!(dattr.odp_caps.per_transport_caps.rc_odp_caps & IBV_ODP_SUPPORT_RECV)) {
-		fprintf(stderr, " Receive is not supported for RC transport.\n");
 		return 0;
 	}
+
+	switch (conn) {
+	case RC:
+		if ( !check_odp_transport_caps(user_param,
+					       dattr.odp_caps.per_transport_caps.rc_odp_caps) )
+			return 0;
+		break;
+
+	case UC:
+		fprintf(stderr," ODP is not available on UC transport.\n");
+		return 0;
+
+	case UD:
+		if ( !check_odp_transport_caps(user_param,
+					       dattr.odp_caps.per_transport_caps.ud_odp_caps) )
+			return 0;
+		break;
+
+	case XRC:
+		if ( !check_odp_transport_caps(user_param, dattr.xrc_odp_caps) )
+			return 0;
+		break;
+
+	case DC:
+		/* A Dynamically Connected transport service is specific to mlx5 devices.
+		 * ODP is available, but the device driver does not register the capabilities,
+		 * so we cannot get them with ibv_query_device_ex(). They are configured in
+		 * libmlx5 and can be gained with an experimental API ibv_exp_query_device(),
+		 * but we should stick to generic functions, so let's skip checking them. */
+		break;
+
+	case SRD:
+		/* Scalable Reliable Datagram is Ethernet-based transport protocol specific to
+		 * AWS Elastic Fabric Adapter. ODP is not implemented. */
+		fprintf(stderr, " ODP is not available on SRD transport.\n");
+		return 0;
+
+	default:
+		fprintf(stderr, " Unsupported connection type.\n");
+		return 0;
+	}
+
 	return 1;
 }
 #endif
@@ -1659,7 +1732,7 @@ int create_single_mr(struct pingpong_context *ctx, struct perftest_parameters *u
 	/* ODP */
 	#ifdef HAVE_EX_ODP
 	if (user_param->use_odp) {
-		if ( !check_odp_support(ctx) )
+		if ( !check_odp_support(ctx, user_param) )
 			return FAILURE;
 
 		/* ODP does not support contig pages */


### PR DESCRIPTION
RDMA atomic with ODP is already enabled in the mlx5 driver.
There is no reason to block the feature.
cf. https://github.com/torvalds/linux/commit/17d2f88f92ce39b348f125f6b2e6eeb6b0906ac7

Signed-off-by: Daisuke Matsuda <matsuda-daisuke@fujitsu.com>