### PR TITLE
perftest_parameters: Add inline feature support of ERDMA device

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1851,6 +1851,7 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 			case 55300 : dev_fname = NETXTREME; break;
 			case 61344 : dev_fname = EFA; break;
 			case 61345 : dev_fname = EFA; break;
+			case 4223  : dev_fname = ERDMA; break;
 			default	   : dev_fname = UNKNOWN;
 		}
 	}
@@ -2054,6 +2055,8 @@ static void ctx_set_max_inline(struct ibv_context *context,struct perftest_param
 				user_param->inline_size = 32;
 			else if (current_dev == QLOGIC_E4)
 				user_param->inline_size = 128;
+			else if (current_dev == ERDMA)
+				user_param->inline_size = 96;
 
 		} else {
 			user_param->inline_size = 0;

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -380,6 +380,7 @@ enum ctx_device {
 	CONNECTX7		= 26,
 	QLOGIC_AHP		= 27,
 	BLUEFIELD3		= 28,
+	ERDMA			= 29,
 };
 
 /* Units for rate limiter */


### PR DESCRIPTION
Hi,

ERDMA is a newly added RDMA device, and the max inline size of it is 96 bytes. By default, perftest will disable inline feature for unrecognized devices in LAT test, and erdma is treated as unknown device for now.  

So, this commit aims at to make perftest recognize erdma device, and set the correct max inline size in LAT test.

Thanks,
Cheng Xu