### PR TITLE
Perftest: Add support for HNS

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1860,6 +1860,13 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 			case 55300 : dev_fname = NETXTREME; break;
 			case 61344 : dev_fname = EFA; break;
 			case 61345 : dev_fname = EFA; break;
+			case 41506 : dev_fname = HNS; break;
+			case 41507 : dev_fname = HNS; break;
+			case 41508 : dev_fname = HNS; break;
+			case 41509 : dev_fname = HNS; break;
+			case 41510 : dev_fname = HNS; break;
+			case 41512 : dev_fname = HNS; break;
+			case 41519 : dev_fname = HNS; break;
 			default	   : dev_fname = UNKNOWN;
 		}
 	}
@@ -2063,6 +2070,8 @@ static void ctx_set_max_inline(struct ibv_context *context,struct perftest_param
 				user_param->inline_size = 32;
 			else if (current_dev == QLOGIC_E4)
 				user_param->inline_size = 128;
+			else if (current_dev == HNS)
+				user_param->inline_size = 1024;
 
 		} else {
 			user_param->inline_size = 0;

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -178,8 +178,8 @@
 #define UC_MAX_RX     (16000)
 #define MIN_CQ_MOD    (1)
 #define MAX_CQ_MOD    (1024)
-#define MAX_INLINE    (912)
-#define MAX_INLINE_UD (884)
+#define MAX_INLINE    (1024)
+#define MAX_INLINE_UD (1024)
 #define MIN_EQ_NUM    (0)
 #define MAX_EQ_NUM    (2048)
 
@@ -380,6 +380,7 @@ enum ctx_device {
 	CONNECTX7		= 26,
 	QLOGIC_AHP		= 27,
 	BLUEFIELD3		= 28,
+	HNS			= 29,
 };
 
 /* Units for rate limiter */

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -2042,7 +2042,8 @@ int verify_params_with_device_context(struct ibv_context *context,
 		current_dev != BLUEFIELD &&
 		current_dev != BLUEFIELD2 &&
 		current_dev != BLUEFIELD3 &&
-		current_dev != EFA)
+		current_dev != EFA &&
+		current_dev != HNS)
 	{
 		if (!user_param->use_old_post_send)
 		{


### PR DESCRIPTION
Add support for HNS device by making it recognized by perftest. Or these devices will be treated as unknown devices on which perftest will not allow it to use new post send method and use a wrong max inline size.

Signed-off-by: Chengchang Tang <tangchengchang@huawei.com>