### PR TITLE
Perftest: Add new post send and inline support for HNS

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1861,6 +1861,13 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 			case 61344 : dev_fname = EFA; break;
 			case 61345 : dev_fname = EFA; break;
 			case 4223  : dev_fname = ERDMA; break;
+			case 41506 : dev_fname = HNS; break;
+			case 41507 : dev_fname = HNS; break;
+			case 41508 : dev_fname = HNS; break;
+			case 41509 : dev_fname = HNS; break;
+			case 41510 : dev_fname = HNS; break;
+			case 41512 : dev_fname = HNS; break;
+			case 41519 : dev_fname = HNS; break;
 			default	   : dev_fname = UNKNOWN;
 		}
 	}
@@ -2066,6 +2073,8 @@ static void ctx_set_max_inline(struct ibv_context *context,struct perftest_param
 				user_param->inline_size = 128;
 			else if (current_dev == ERDMA)
 				user_param->inline_size = 96;
+			else if (current_dev == HNS)
+				user_param->inline_size = 32;
 
 		} else {
 			user_param->inline_size = 0;

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -178,8 +178,8 @@
 #define UC_MAX_RX     (16000)
 #define MIN_CQ_MOD    (1)
 #define MAX_CQ_MOD    (1024)
-#define MAX_INLINE    (912)
-#define MAX_INLINE_UD (884)
+#define MAX_INLINE    (1024)
+#define MAX_INLINE_UD (1024)
 #define MIN_EQ_NUM    (0)
 #define MAX_EQ_NUM    (2048)
 

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -381,6 +381,7 @@ enum ctx_device {
 	QLOGIC_AHP		= 27,
 	BLUEFIELD3		= 28,
 	ERDMA			= 29,
+	HNS			= 30,
 };
 
 /* Units for rate limiter */

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -2042,7 +2042,8 @@ int verify_params_with_device_context(struct ibv_context *context,
 		current_dev != BLUEFIELD &&
 		current_dev != BLUEFIELD2 &&
 		current_dev != BLUEFIELD3 &&
-		current_dev != EFA)
+		current_dev != EFA &&
+		current_dev != HNS)
 	{
 		if (!user_param->use_old_post_send)
 		{


### PR DESCRIPTION
HNS roce has been accepted by the rdma-core for a few years now, but it was not supported by Perftest. For this reason, the inline and the new post send of hns cannot be tested in perftest, even though they have been merged to the rdma-core mainline for some time.

In this PR，the first patch add hns roce to the device list. And make it support the new post send and set a default inline size.
The second patch increase the max_inline_data to 1024 to support test for some hns roce device.

