### PR TITLE
Perftest: replace rand() with getrandom() during MR buffer initialization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,7 @@ AC_PROG_LIBTOOL
 AC_PROG_RANLIB
 AC_HEADER_STDC
 AC_CHECK_HEADERS([infiniband/verbs.h],,[AC_MSG_ERROR([ibverbs header files not found])])
+AC_CHECK_HEADERS([sys/random.h],,)
 AC_CHECK_LIB([ibverbs], [ibv_get_device_list], [], [AC_MSG_ERROR([libibverbs not found])])
 AC_CHECK_LIB([rdmacm], [rdma_create_event_channel], [], AC_MSG_ERROR([librdmacm-devel not found]))
 AC_CHECK_LIB([ibumad], [umad_init], [LIBUMAD=-libumad], AC_MSG_ERROR([libibumad not found]))


### PR DESCRIPTION
rand() has very poor performance in some OS.

ib_send_bw will spend a lot of time during MR initialization when testing large packects in above scenario.

A simple test has been done:
```c
#define HUGE_MR_SIZE 2147483647
int main(int argc, char *argv[])
{
        char *a = malloc(HUGE_MR_SIZE * sizeof(char));
        unsigned int i;
        char *tmp = a;
        int ret;

        srand(time(NULL));
        if (a == NULL)
                exit(1);

        if (argc <= 1)
                goto fall_back;

        for (i = HUGE_MR_SIZE; i > 0;) {
                ret = getrandom(tmp, i, 0);
                if (ret < 0)
                        goto fall_back;
                tmp += ret;
                i -= ret;
        }
        goto out;

fall_back:
        for(i = 0; i < HUGE_MR_SIZE; i++)
                a[i] = (char)rand();
out:
        free(a);
        return 0;
}
```
```bash
time ./a.out
real    5m35.033s
user    5m33.546s
sys     0m0.918s

time ./a.out 1

real    0m6.454s
user    0m0.000s
sys     0m6.449s
```
As shown in the test above, getrandom() has a much better performance, so replace rand() with it. 
The test in perftest has also been done.

This patch fixes https://github.com/linux-rdma/perftest/issues/89

Signed-off-by: Chengchang Tang <tangchengchang@huawei.com>