### PR TITLE
Perftest: Fix verification of max_inline_data for *_create_qp_ex()

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -2437,22 +2437,21 @@ struct ibv_qp* ctx_qp_create(struct pingpong_context *ctx,
 	int dc_num_of_qps = user_param->num_of_qps / 2;
 
 	int is_dc_server_side = 0;
+	struct ibv_qp_init_attr attr;
+	memset(&attr, 0, sizeof(struct ibv_qp_init_attr));
+	struct ibv_qp_cap *qp_cap = &attr.cap;
+
 	#ifdef HAVE_IBV_WR_API
 	enum ibv_wr_opcode opcode;
-	struct ibv_qp_init_attr attr;
 	struct ibv_qp_init_attr_ex attr_ex;
+	memset(&attr_ex, 0, sizeof(struct ibv_qp_init_attr_ex));
 	#ifdef HAVE_MLX5DV
 	struct mlx5dv_qp_init_attr attr_dv;
 	memset(&attr_dv, 0, sizeof(attr_dv));
 	#endif
-	memset(&attr, 0, sizeof(struct ibv_qp_init_attr));
-	memset(&attr_ex, 0, sizeof(struct ibv_qp_init_attr_ex));
 	#ifdef HAVE_SRD
 	struct efadv_qp_init_attr efa_attr = {};
 	#endif
-	#else
-	struct ibv_qp_init_attr attr;
-	memset(&attr, 0, sizeof(struct ibv_qp_init_attr));
 	#endif
 
 	attr.send_cq = ctx->send_cq;
@@ -2627,10 +2626,15 @@ struct ibv_qp* ctx_qp_create(struct pingpong_context *ctx,
 		fprintf(stderr, "Current TX depth is %d and inline size is %d .\n", user_param->tx_depth, user_param->inline_size);
 	}
 
-	if (user_param->inline_size > attr.cap.max_inline_data) {
-		user_param->inline_size = attr.cap.max_inline_data;
-		printf("  Actual inline-size(%d) > requested inline-size(%d)\n",
-			attr.cap.max_inline_data, user_param->inline_size);
+	#ifdef HAVE_IBV_WR_API
+	if (!user_param->use_old_post_send)
+		qp_cap = &attr_ex.cap;
+	#endif
+
+	if (user_param->inline_size > qp_cap->max_inline_data) {
+		printf("  Actual inline-size(%d) < requested inline-size(%d)\n",
+			qp_cap->max_inline_data, user_param->inline_size);
+		user_param->inline_size = qp_cap->max_inline_data;
 	}
 
 	return qp;


### PR DESCRIPTION
As described in the link, the ibv_create_qp_ex returns the actual QP value via qp_init_attr_ex：
https://github.com/linux-rdma/rdma-core/blob/master/libibverbs/man/ibv_create_qp_ex.3

Currently, qp_init_attr.cap.max_inline_data is used for validation both in *_create_qp() and *_create_qp_ex(). But actually, when entering the create_qp_ex path, the variable qp_init_attr is not used. So the current check for the *_create_qp_ex() branch is meaningless.

The qp_init_attr_ex.cap.max_inline_data is used to check the max_inline_data in *_create_qp_ex() path in this patch. And related printing error has also been fixed.

Fixes: 13f71777e6f0 ("Added new post_send API usage for RC,UC,UD,XRC")
Signed-off-by: Chengchang Tang <tangchengchang@huawei.com>