### PR TITLE
Fix tx_depth when test method is RUN_INFINITELY

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1008,7 +1008,7 @@ void flow_rules_force_dependecies(struct perftest_parameters *user_param)
 static void force_dependecies(struct perftest_parameters *user_param)
 {
 	/*Additional configuration and assignments.*/
-	if (user_param->test_type == ITERATIONS) {
+	if (user_param->test_method != RUN_INFINITELY && user_param->test_type == ITERATIONS) {
 		if (user_param->tx_depth > user_param->iters) {
 			user_param->tx_depth = user_param->iters;
 		}


### PR DESCRIPTION
The original if statement will force the tx_depth to be less than iters, which is 1000 by default, even if the user runs with --run_infinitely option in which case the iters option is useless. So a user may not get what it wants when setting --run_infinitely and -t at the same time.

Signed-off-by: DillionApple <DillionMango@gmail.com>