### PR TITLE
Perftest: remove code checked by RSS_EXP verbs macro

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1521,14 +1521,6 @@ static void force_dependecies(struct perftest_parameters *user_param)
 		user_param->cq_mod = 1;
 	}
 
-	#ifndef HAVE_RSS_EXP
-	if (user_param->use_rss) {
-		printf(RESULT_LINE);
-		fprintf(stderr," RSS feature is not available in libibverbs\n");
-		exit(1);
-	}
-	#endif
-
 	if ((user_param->use_srq && (user_param->tst == LAT || user_param->machine == SERVER || user_param->duplex == ON)) || user_param->use_xrc)
 		user_param->srq_exists = 1;
 
@@ -2597,7 +2589,9 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			case 'P': user_param->machine = CLIENT; break;
 			case 'Z': user_param->machine = SERVER; break;
 			case 'v': user_param->mac_fwd = ON; break;
-			case 'G': user_param->use_rss = ON; break;
+			case 'G':
+				fprintf(stderr, "RSS isn't supported\n");
+				return FAILURE;
 			case 0: /* required for long options to work. */
 				if (pkey_flag) {
 					CHECK_VALUE(user_param->pkey_index,int,"Pkey index",not_int_ptr);

--- a/src/raw_ethernet_send_bw.c
+++ b/src/raw_ethernet_send_bw.c
@@ -125,15 +125,6 @@ int main(int argc, char *argv[])
 
 	}
 
-	if (user_param.use_rss) {
-		/* if num_of_qps is not even, set it to 2. */
-		if (user_param.num_of_qps % 2)
-			user_param.num_of_qps = 2;
-
-		/* add another one for rss parent QP */
-		user_param.num_of_qps += 1;
-	}
-
 	/* Finding the IB device selected (or default if no selected). */
 	ib_dev = ctx_find_dev(&user_param.ib_devname);
 	if (!ib_dev) {


### PR DESCRIPTION
In 4948417abacf("Removed some features that are not supported in rdma-core"), HAVE_RSS_EXP feature has been removed.

Signed-off-by: Liu, Changcheng <changcheng.liu@aliyun.com>