### PR TITLE
Perftest: remove unused internal API parameter

### DIFF
--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -2296,7 +2296,7 @@ int rdma_cm_route_handler(struct pingpong_context *ctx,
 	}
 
 	ctx->cm_id = cma_id;
-	rc = create_qp_main(ctx, user_param, connection_index, 0);
+	rc = create_qp_main(ctx, user_param, connection_index);
 	if (rc) {
 		error_message = "Failed to create QP.";
 		goto error;
@@ -2363,7 +2363,7 @@ int rdma_cm_connection_request_handler(struct pingpong_context *ctx,
 	}
 
 	ctx->cm_id = cm_node->cma_id;
-	rc = create_qp_main(ctx, user_param, connection_index, 0);
+	rc = create_qp_main(ctx, user_param, connection_index);
 	if (rc) {
 		error_message = "Failed to create QP.";
 		goto error_2;

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -2217,7 +2217,6 @@ static int verify_ooo_settings(struct pingpong_context *ctx,
 int ctx_init(struct pingpong_context *ctx, struct perftest_parameters *user_param)
 {
 	int i;
-	int num_of_qps = user_param->num_of_qps / 2;
 	int dct_only = (user_param->machine == SERVER && !(user_param->duplex || user_param->tst == LAT));
 	int qp_index = 0, dereg_counter;
 	#ifdef HAVE_AES_XTS
@@ -2414,13 +2413,13 @@ int ctx_init(struct pingpong_context *ctx, struct perftest_parameters *user_para
 		return SUCCESS;
 
 	for (i=0; i < user_param->num_of_qps; i++) {
-		if (create_qp_main(ctx, user_param, i, num_of_qps)) {
+		if (create_qp_main(ctx, user_param, i)) {
 			fprintf(stderr, "Failed to create QP.\n");
 			goto qps;
 		}
 
 		if (user_param->work_rdma_cm == OFF) {
-			modify_qp_to_init(ctx, user_param, i, num_of_qps);
+			modify_qp_to_init(ctx, user_param, i);
 		}
 		#ifdef HAVE_DCS
 		ctx->dci_stream_id[i] = 0;
@@ -2486,7 +2485,7 @@ comp_channel:
 }
 
 int modify_qp_to_init(struct pingpong_context *ctx,
-		struct perftest_parameters *user_param, int qp_index, int num_of_qps)
+		struct perftest_parameters *user_param, int qp_index)
 {
 	if (ctx_modify_qp_to_init(ctx->qp[qp_index], user_param,
 		qp_index)) {
@@ -2502,7 +2501,7 @@ int modify_qp_to_init(struct pingpong_context *ctx,
  ******************************************************************************/
 int create_reg_qp_main(struct pingpong_context *ctx,
 				struct perftest_parameters *user_param,
-				int i, int num_of_qps)
+				int i)
 {
 	if (user_param->use_xrc) {
 		#ifdef HAVE_XRCD
@@ -2537,10 +2536,10 @@ int create_reg_qp_main(struct pingpong_context *ctx,
 }
 
 int create_qp_main(struct pingpong_context *ctx,
-		struct perftest_parameters *user_param, int i, int num_of_qps)
+		struct perftest_parameters *user_param, int i)
 {
 	int ret;
-	ret = create_reg_qp_main(ctx, user_param, i, num_of_qps);
+	ret = create_reg_qp_main(ctx, user_param, i);
 	return ret;
 }
 

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -801,13 +801,13 @@ int check_packet_pacing_support(struct pingpong_context *ctx);
 #endif
 
 int create_reg_qp_main(struct pingpong_context *ctx,
-		struct perftest_parameters *user_param, int i, int num_of_qps);
+		struct perftest_parameters *user_param, int i);
 
 int create_qp_main(struct pingpong_context *ctx,
-		struct perftest_parameters *user_param, int i, int num_of_qps);
+		struct perftest_parameters *user_param, int i);
 
 int modify_qp_to_init(struct pingpong_context *ctx,
-                struct perftest_parameters *user_param, int qp_index, int num_of_qps);
+        struct perftest_parameters *user_param, int qp_index);
 
 
 /* create_single_mr


### PR DESCRIPTION
After merging 4948417abacf, num_of_qps won't be used anymore. Remove it now.

Signed-off-by: Liu, Changcheng <changcheng.liu@aliyun.com>