### PR TITLE
Perftest: refine ctx_modify_qp_to_rts parameter type

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -2923,13 +2923,12 @@ static int ctx_modify_qp_to_rtr(struct ibv_qp *qp,
  *
  ******************************************************************************/
 static int ctx_modify_qp_to_rts(struct ibv_qp *qp,
-		void *_attr,
+		struct ibv_qp_attr *attr,
 		struct perftest_parameters *user_param,
 		struct pingpong_dest *dest,
 		struct pingpong_dest *my_dest)
 {
 	int flags = IBV_QP_STATE;
-	struct ibv_qp_attr *attr = (struct ibv_qp_attr*)_attr;
 
 	attr->qp_state = IBV_QPS_RTS;
 


### PR DESCRIPTION
In 4948417abacf("Removed some features that are not supported in rdma-core"), HAVE_VERBS_EXP feature has been removed. The parameter _attr should be only struct ibv_qp_attr *.

Signed-off-by: Liu, Changcheng <changcheng.liu@aliyun.com>