### PR TITLE
Perftest: enable inherit environment LDFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -310,6 +310,7 @@ if [test $HAVE_MLX5DV_LIB = yes] && [test $HAVE_MLX5DV = yes]; then
 fi
 
 CFLAGS="-g -Wall -D_GNU_SOURCE -O3 $CFLAGS"
+LDFLAGS="$LDFLAGS"
 LIBS=$LIBS" -lpthread"
 AC_SUBST([LIBUMAD])
 AC_SUBST([LIBMATH])


### PR DESCRIPTION
Sometimes, it needs to use environment to specify the library path to be linked during development stage if the library doesn't exist in system installed path. enable inherit environment LDFLAGS in configure to support it.

Signed-off-by: Liu, Changcheng <changcheng.liu@aliyun.com>