### PR TITLE
Perftest: add null mr option

### DIFF
--- a/man/perftest.1
+++ b/man/perftest.1
@@ -339,6 +339,9 @@ many different options and modes.
  Set the Traffic Class in GRH (if GRH is in use).
  Not relevant for raw_ethernet_fs_rate.
 .TP
+.B --use-null-mr
+ Allocate a null memory region for the client with \fBibv_alloc_null_mr\fR(3)
+.TP
 .B --use_cuda=<cuda device id>
  Use CUDA specific device for GPUDirect RDMA testing.
  Not relevant for raw_ethernet_fs_rate.

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -492,6 +492,7 @@ struct perftest_parameters {
 	int				is_ethertype;
 	int				cpu_freq_f;
 	int				connection_type;
+	int				use_null_mr;
 	int				num_of_qps;
 	int				use_event;
 	int				eq_num;

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1925,6 +1925,14 @@ int create_single_mr(struct pingpong_context *ctx, struct perftest_parameters *u
 		}
 	}
 
+	if (user_param->use_null_mr) {
+		ctx->null_mr = ibv_alloc_null_mr(ctx->pd);
+		if (!ctx->null_mr) {
+			fprintf(stderr, "Couldn't create null MR\n");
+			return FAILURE;
+		}
+	}
+
 	if (ctx->is_contig_supported == SUCCESS)
 		ctx->buf[qp_index] = ctx->mr[qp_index]->addr;
 
@@ -3304,6 +3312,9 @@ void ctx_set_send_reg_wqes(struct pingpong_context *ctx,
 				(user_param->connection_type == RawEth) ? (user_param->size - HW_CRC_ADDITION) : user_param->size;
 
 			ctx->sge_list[i*user_param->post_list + j].lkey = ctx->mr[i]->lkey;
+			if (user_param->use_null_mr) {
+				ctx->sge_list[i*user_param->post_list + j].lkey = ctx->null_mr->lkey;
+			}
 
 			if (j > 0) {
 

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -168,6 +168,7 @@ struct pingpong_context {
 	struct ibv_comp_channel			*channel;
 	struct ibv_pd				*pd;
 	struct ibv_mr				**mr;
+	struct ibv_mr				*null_mr;
 	struct ibv_cq				*send_cq;
 	struct ibv_cq				*recv_cq;
 	void					**buf;


### PR DESCRIPTION
On a single system, using a null MR can be used to generate unidirectional PCIe traffic to or from the device. Without a null mr, PCIe traffic is generated to and from the device and might saturate memory bandwidth.