### PR TITLE
Added ctx->cma_master.disconnects_left parameter

### DIFF
--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -2422,6 +2422,7 @@ int rdma_cm_connection_request_handler(struct pingpong_context *ctx,
 	ctx->cma_master.nodes[connection_index].connected = 1;
 	ctx->cma_master.connection_index++;
 	ctx->cma_master.connects_left--;
+	ctx->cma_master.disconnects_left++;
 	return rc;
 
 error_2:


### PR DESCRIPTION
The rdma_disconnect API is called on both the server and client sides during connection termination based on the disconnect_left value, but the disconnect_left is missing in the server, which results in the server not calling disconnect during termination, which causes an error.

1. either the client-side disconnect fails.
2. Despite the fact that the rdma_disconnect was successful, the RDMA_CM_EVENT_DISCONNECTED was not sending the target to the client, which is only sent if the rdma_disconnect is called at the server side. As a result, the count of disconnect_left does not decrease, and the client continues to wait for RDMA_CM_EVENT_DISCONNECTED indefinitely.

By adding the disconnect_left parameter at server-side, both the server and client will call the disconnect API, and the client will send RDMA_CM_EVENT_DISCONNECTED to the server and the server will send RDMA_CM_EVENT_DISCONNECTED to the client, thus decrementing disconnect_left on both sides.