### PR TITLE
Modify --source_ip to --bind_sounce_ip to fix init connection establishment with specific interface

### DIFF
--- a/man/perftest.1
+++ b/man/perftest.1
@@ -268,7 +268,7 @@ many different options and modes.
  Use IPv6 GID. Default is IPv4.
  Not relevant for RawEth.
 .TP
-.B --source_ip
+.B --bind_source_ip
  Source IP of the interface used for connection establishment. By default taken from routing table.
  Not relevant for RawEth.
 .TP

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -465,7 +465,7 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 
 	// please note it is a different source_ip from raw_ethernet case
 	if (connection_type != RawEth) {
-		printf("      --source_ip ");
+		printf("      --bind_source_ip ");
 		printf(" Source IP of the interface used for connection establishment. By default taken from routing table.\n");
 	}
 
@@ -2375,7 +2375,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			#if defined HAVE_OOO_ATTR
 			{.name = "use_ooo", .has_arg = 0, .flag = &use_ooo_flag, .val = 1},
 			#endif
-			{.name = "source_ip", .has_arg = 1, .flag = &source_ip_flag, .val = 1},
+			{.name = "bind_source_ip", .has_arg = 1, .flag = &source_ip_flag, .val = 1},
 			{0}
 		};
 		if (!duplicates_checker) {
@@ -2387,7 +2387,6 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 
 		/* c == 0: the argumenet is a long option (example: --report_gbits) */
 		/* c > 0: the argument is a short option (example: -s/--size) */
-		printf("line %d: c = %d\n", __LINE__, c);
 		if (c == 0) {
 			if (duplicates_checker[long_option_index]) {
 				fprintf(stderr," Duplicated argument: %s \n", long_options[long_option_index].name);
@@ -2405,7 +2404,6 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			}
 			duplicates_checker[char_index]++;
 		}
-		printf("line %d: c = %d\n", __LINE__, c);
 
 		if (c == -1)
 			break;
@@ -2670,7 +2668,6 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				free(duplicates_checker);
 				return FAILURE;
 			case 0: /* required for long options to work. */
-				printf("enter long options\n");
 				if (pkey_flag) {
 					CHECK_VALUE(user_param->pkey_index,int,"Pkey index",not_int_ptr);
 					pkey_flag = 0;

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -2387,6 +2387,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 
 		/* c == 0: the argumenet is a long option (example: --report_gbits) */
 		/* c > 0: the argument is a short option (example: -s/--size) */
+		printf("line %d: c = %d\n", __LINE__, c);
 		if (c == 0) {
 			if (duplicates_checker[long_option_index]) {
 				fprintf(stderr," Duplicated argument: %s \n", long_options[long_option_index].name);
@@ -2404,6 +2405,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			}
 			duplicates_checker[char_index]++;
 		}
+		printf("line %d: c = %d\n", __LINE__, c);
 
 		if (c == -1)
 			break;
@@ -2668,6 +2670,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				free(duplicates_checker);
 				return FAILURE;
 			case 0: /* required for long options to work. */
+				printf("enter long options\n");
 				if (pkey_flag) {
 					CHECK_VALUE(user_param->pkey_index,int,"Pkey index",not_int_ptr);
 					pkey_flag = 0;
@@ -2893,8 +2896,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 					local_ip = optarg;
 					local_ip_flag = 0;
 				}
-				if (source_ip_flag)
-				{
+				if (source_ip_flag) {
 					user_param->has_source_ip = 1;
 					GET_STRING(user_param->source_ip, strdupa(optarg));
 					source_ip_flag = 0;


### PR DESCRIPTION
When there are several network interface with different subnet address, perftest tools will always choose default route even I add --source_ip option to ask perftest to bind an interface.
I found there are two options use same name called "--source_ip". Therefore I add a prefix "raw_" for raw eth series options to avoid further using two same option name when adding new options.

BR,
Huai-En, Tseng