### PR TITLE
SRD CQ notifications

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1531,11 +1531,6 @@ static void force_dependecies(struct perftest_parameters *user_param)
 			fprintf(stderr, " SRD does not support RDMA_CM\n");
 			exit(1);
 		}
-		if (user_param->use_event == ON) {
-			printf(RESULT_LINE);
-			fprintf(stderr, " SRD does not support events\n");
-			exit(1);
-		}
 		user_param->cq_mod = 1;
 	}
 

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -132,6 +132,13 @@
 
 #define MASK_IS_SET(mask, attr)      (((mask)&(attr))!=0)
 
+#define MAX(a, b) \
+	({ \
+		typeof(a) _a = (a); \
+		typeof(b) _b = (b); \
+		_a > _b ? _a : _b; \
+	})
+
 /******************************************************************************
  * Perftest resources Structures and data types.
  ******************************************************************************/
@@ -165,7 +172,8 @@ struct pingpong_context {
 	struct mlx5dv_mkey			**mkey;
 	struct mlx5dv_dek			**dek;
 	#endif
-	struct ibv_comp_channel			*channel;
+	struct ibv_comp_channel			*recv_channel;
+	struct ibv_comp_channel			*send_channel;
 	struct ibv_pd				*pd;
 	struct ibv_mr				**mr;
 	struct ibv_mr				*null_mr;
@@ -743,6 +751,40 @@ static __inline void increase_rem_addr(struct ibv_send_wr *wr,int size,uint64_t 
 		else
 			wr->wr.rdma.remote_addr = prim_addr;
 	}
+}
+
+/*
+ * Block until any event (send or receive) is available, and rearm the
+ * appropriate completion channel.
+ */
+static __inline int ctx_notify_send_recv_events(struct pingpong_context *ctx)
+{
+	fd_set rfds;
+
+	FD_ZERO(&rfds);
+	FD_SET(ctx->recv_channel->fd, &rfds);
+	FD_SET(ctx->send_channel->fd, &rfds);
+
+	if (select(MAX(ctx->recv_channel->fd,
+		       ctx->send_channel->fd) + 1,
+		   &rfds, NULL, NULL, NULL) == -1) {
+		fprintf(stderr, "Failed to get completion events\n");
+		return FAILURE;
+	}
+
+	if (FD_ISSET(ctx->recv_channel->fd, &rfds) &&
+	    ctx_notify_events(ctx->recv_channel)) {
+		fprintf(stderr,"Failed to notify receive events to CQ");
+		return FAILURE;
+	}
+
+	if (FD_ISSET(ctx->send_channel->fd, &rfds) &&
+	    ctx_notify_events(ctx->send_channel)) {
+		fprintf(stderr,"Failed to notify send events to CQ");
+		return FAILURE;
+	}
+
+	return SUCCESS;
 }
 
 /* increase_loc_addr.

--- a/src/raw_ethernet_resources.c
+++ b/src/raw_ethernet_resources.c
@@ -1046,8 +1046,7 @@ int run_iter_fw(struct pingpong_context *ctx,struct perftest_parameters *user_pa
 		}
 
 		if (user_param->use_event) {
-
-			if (ctx_notify_events(ctx->channel)) {
+			if (ctx_notify_send_recv_events(ctx)) {
 				fprintf(stderr, "Failed to notify events to CQ");
 				return_value = FAILURE;
 				goto cleaning;


### PR DESCRIPTION
Add support for SRD CQ notifications.
The first patch fixes a bug where the same completion channel is used for both TX and RX and messes up the test.

Replaces PR https://github.com/linux-rdma/perftest/pull/127.