### PR TITLE
Revert "Perftest: replace rand() with getrandom() during MR buffer in initialization"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,6 @@ AC_PROG_LIBTOOL
 AC_PROG_RANLIB
 AC_HEADER_STDC
 AC_CHECK_HEADERS([infiniband/verbs.h],,[AC_MSG_ERROR([ibverbs header files not found])])
-AC_CHECK_HEADERS([sys/random.h],,)
 AC_CHECK_LIB([ibverbs], [ibv_get_device_list], [], [AC_MSG_ERROR([libibverbs not found])])
 AC_CHECK_LIB([rdmacm], [rdma_create_event_channel], [], AC_MSG_ERROR([librdmacm-devel not found]))
 AC_CHECK_LIB([ibumad], [umad_init], [LIBUMAD=-libumad], AC_MSG_ERROR([libibumad not found]))


### PR DESCRIPTION
Revert "Perftest: replace rand() with getrandom() during MR buffer in initialization"

This reverts commit e4cd0f70f001b4dfc2b199d943de974328600861.