### PR TITLE
Perftest: add --report-min-bw to sample minimum bandwidth over X iterations

### DIFF
--- a/man/perftest.1
+++ b/man/perftest.1
@@ -334,6 +334,10 @@ many different options and modes.
  Not relevant for RawEth.
  System support required.
 .TP
+.B --report-min-bw=<iterations>
+ Sample minimum bandwidth over X iterations.
+ Relevant only for bandwidth.
+.TP
 .B --reversed
  Reverse traffic direction - Server send to client.
 .TP

--- a/src/atomic_bw.c
+++ b/src/atomic_bw.c
@@ -243,7 +243,11 @@ int main(int argc, char *argv[])
 	if (user_param.machine == SERVER && !user_param.duplex) {
 		if (user_param.output == FULL_VERBOSITY) {
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			if (user_param.report_min_bw) {
+				printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+			} else {
+				printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			}
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 		}
 
@@ -301,7 +305,11 @@ int main(int argc, char *argv[])
 	}
 	if (user_param.output == FULL_VERBOSITY) {
 		printf(RESULT_LINE);
-		printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+		if (user_param.report_min_bw) {
+			printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+		} else {
+			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+		}
 		printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 	}
 
@@ -339,14 +347,22 @@ int main(int argc, char *argv[])
 			printf(RESULT_LINE);
 			printf("\n Local results:\n");
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			if (user_param.report_min_bw) {
+				printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+			} else {
+				printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			}
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 			print_full_bw_report(&user_param, &my_bw_rep, NULL);
 			printf(RESULT_LINE);
 
 			printf("\n Remote results:\n");
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			if (user_param.report_min_bw) {
+				printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+			} else {
+				printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			}
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 			print_full_bw_report(&user_param, &rem_bw_rep, NULL);
 		}

--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -1928,6 +1928,7 @@ void xchg_bw_reports (struct perftest_comm *comm, struct bw_report_data *my_bw_r
 	temp.msgRate_avg = hton_double(my_bw_rep->msgRate_avg);
 	temp.msgRate_avg_p1 = hton_double(my_bw_rep->msgRate_avg_p1);
 	temp.msgRate_avg_p2 = hton_double(my_bw_rep->msgRate_avg_p2);
+	temp.bw_min = hton_double(my_bw_rep->bw_min);
 
 	/*******************Exchange Reports*******************/
 	if (ctx_xchg_data(comm, (void*) (&temp.size), (void*) (&rem_bw_rep->size), sizeof(unsigned long))) {
@@ -1973,6 +1974,11 @@ void xchg_bw_reports (struct perftest_comm *comm, struct bw_report_data *my_bw_r
 			exit(1);
 		}
 	}
+	if (ctx_xchg_data(comm, (void*) (&temp.bw_min), (void*) (&rem_bw_rep->bw_min), sizeof(double))) {
+		fprintf(stderr," Failed to exchange data between server and clients\n");
+		exit(1);
+	}
+
 	// cppcheck-suppress selfAssignment
 	rem_bw_rep->size = hton_long(rem_bw_rep->size);
 
@@ -1997,6 +2003,8 @@ void xchg_bw_reports (struct perftest_comm *comm, struct bw_report_data *my_bw_r
 	rem_bw_rep->msgRate_avg_p1 = hton_double(rem_bw_rep->msgRate_avg_p1);
 	// cppcheck-suppress selfAssignment
 	rem_bw_rep->msgRate_avg_p2 = hton_double(rem_bw_rep->msgRate_avg_p2);
+	// cppcheck-suppress selfAssignment
+	rem_bw_rep->bw_min = hton_double(rem_bw_rep->bw_min);
 
 }
 

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -729,6 +729,9 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 
 		printf("      --run_infinitely ");
 		printf(" Run test forever, print results every <duration> seconds (SYMMETRIC)\n");
+
+		printf("      --report-min-bw=<sample iterations>\n");
+		printf(" Sample minimum bandwidth over X iterations\n");
 	}
 
 	if (connection_type != RawEth) {
@@ -1074,6 +1077,7 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->vlan_en             = OFF;
 	user_param->vlan_pcp		= 1;
 	user_param->print_eth_func 	= &print_ethernet_header;
+	user_param->report_min_bw   = 0;
 
 	if (user_param->tst == LAT) {
 		user_param->r_flag->unsorted	= OFF;
@@ -2419,6 +2423,13 @@ static void force_dependecies(struct perftest_parameters *user_param)
 		#endif
 	}
 
+	if (user_param->report_min_bw > 0) {
+		if (user_param->tst != BW) {
+			printf(" Sample minimum bandwidth only supports BW tests.\n");
+			exit (1);
+		}
+	}
+
 	return;
 }
 /******************************************************************************
@@ -2988,6 +2999,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	#ifdef HAVE_SRD_WITH_UNSOLICITED_WRITE_RECV
 	static int unsolicited_write_flag = 0;
 	#endif
+	static int report_min_bw_flag = 0;
 	#ifdef HAVE_DCS
 	static int log_dci_streams_flag = 0;
 	static int log_active_dci_streams_flag = 0;
@@ -3159,6 +3171,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{ .name = "raw_ipv6",		.has_arg = 0, .flag = &raw_ipv6_flag, .val = 1},
 			#endif
 			{.name = "report-per-port", .has_arg = 0, .flag = &report_per_port_flag, .val = 1},
+			{.name = "report-min-bw", .has_arg = 1, .flag = &report_min_bw_flag, .val = 1},
 			{.name = "odp", .has_arg = 0, .flag = &odp_flag, .val = 1},
 			{.name = "use_hugepages", .has_arg = 0, .flag = &hugepages_flag, .val = 1},
 			{.name = "use_old_post_send", .has_arg = 0, .flag = &old_post_send_flag, .val = 1},
@@ -3934,6 +3947,10 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 					CHECK_VALUE(user_param->recv_post_list,int,"Receive Post List size",not_int_ptr);
 					recv_post_list_flag = 0;
 				}
+				if (report_min_bw_flag) {
+					CHECK_VALUE(user_param->report_min_bw,int,"report min bandwidth interval",not_int_ptr);
+					report_min_bw_flag = 0;
+				}
 				#ifdef HAVE_AES_XTS
 				if (aes_xts_flag) {
 					user_param->aes_xts = 1;
@@ -4705,6 +4722,12 @@ void print_report_bw (struct perftest_parameters *user_param, struct bw_report_d
 	my_bw_rep->msgRate_avg_p2 = msgRate_avg_p2;
 	my_bw_rep->sl = user_param->sl;
 
+	if(user_param->report_min_bw) {
+		my_bw_rep->bw_min = ((double)tsize*user_param->report_min_bw*cycles_to_units) / (user_param->report_min_bw_cycles * format_factor);
+	} else {
+		my_bw_rep->bw_min = 0;
+	}
+
 	if (!user_param->duplex
 	    || (has_recv_comp(user_param->verb) && user_param->test_type == DURATION)
 	    || user_param->test_method == RUN_INFINITELY || user_param->connection_type == RawEth)
@@ -4829,7 +4852,7 @@ static void write_test_info_to_file(int out_json_fds, struct perftest_parameters
 }
 
 static void write_bw_report_to_file(int out_json_fd, struct perftest_parameters *user_param, int inc_accuracy,
-		double bw_avg, double msgRate_avg, unsigned long size, int sl, uint64_t iters, double bw_peak) {
+		double bw_avg, double msgRate_avg, unsigned long size, int sl, uint64_t iters, double bw_peak, double bw_min) {
 
 	dprintf(out_json_fd, "\"results\": {\n");
 
@@ -4837,8 +4860,13 @@ static void write_bw_report_to_file(int out_json_fd, struct perftest_parameters 
 		dprintf(out_json_fd, "\"bw_avg\": %lf,\n", bw_avg);
 	else if (user_param->output == OUTPUT_MR)
 		dprintf(out_json_fd, "\"msgRate_avg\": %lf,\n", msgRate_avg);
+	else if (user_param->raw_qos && user_param->report_min_bw)
+		dprintf(out_json_fd, REPORT_FMT_QOS_JSON_MINBW, size, sl, iters, bw_peak, bw_avg, msgRate_avg, bw_min);
 	else if (user_param->raw_qos)
 		dprintf(out_json_fd, REPORT_FMT_QOS_JSON, size, sl, iters, bw_peak, bw_avg, msgRate_avg);
+	else if (user_param->report_min_bw)
+		dprintf(out_json_fd, inc_accuracy ? REPORT_FMT_EXT_JSON_MINBW : REPORT_FMT_JSON_MINBW,
+								   size, iters, bw_peak, bw_avg, msgRate_avg, bw_min);
 	else
 		dprintf(out_json_fd, inc_accuracy ? REPORT_FMT_EXT_JSON : REPORT_FMT_JSON,
 								   size, iters, bw_peak, bw_avg, msgRate_avg);
@@ -4863,6 +4891,7 @@ void print_full_bw_report (struct perftest_parameters *user_param, struct bw_rep
 	double msgRate_avg = my_bw_rep->msgRate_avg;
 	double msgRate_avg_p1 = my_bw_rep->msgRate_avg_p1;
 	double msgRate_avg_p2 = my_bw_rep->msgRate_avg_p2;
+	double bw_min      = my_bw_rep->bw_min;
 	int inc_accuracy = ((bw_avg < 0.1) && (user_param->report_fmt == GBS));
 
 	if (rem_bw_rep != NULL) {
@@ -4873,6 +4902,7 @@ void print_full_bw_report (struct perftest_parameters *user_param, struct bw_rep
 		msgRate_avg += rem_bw_rep->msgRate_avg;
 		msgRate_avg_p1 += rem_bw_rep->msgRate_avg_p1;
 		msgRate_avg_p2 += rem_bw_rep->msgRate_avg_p2;
+		bw_min         += rem_bw_rep->bw_min;
 	}
 
 	if ((user_param->duplex && rem_bw_rep != NULL) ||  (!user_param->duplex && rem_bw_rep == NULL)
@@ -4895,7 +4925,7 @@ void print_full_bw_report (struct perftest_parameters *user_param, struct bw_rep
 			dprintf(out_json_fd,"{\n");
 			write_test_info_to_file(out_json_fd, user_param);
 			write_bw_report_to_file(out_json_fd, user_param, inc_accuracy,
-					bw_avg, msgRate_avg, my_bw_rep->size, my_bw_rep->sl, my_bw_rep->iters, bw_peak);
+					bw_avg, msgRate_avg, my_bw_rep->size, my_bw_rep->sl, my_bw_rep->iters, bw_peak, bw_min);
 			dprintf(out_json_fd,"}\n");
 			close(out_json_fd);
 		}
@@ -4905,10 +4935,14 @@ void print_full_bw_report (struct perftest_parameters *user_param, struct bw_rep
 		printf("%lf\n",bw_avg);
 	else if (user_param->output == OUTPUT_MR)
 		printf("%lf\n",msgRate_avg);
+	else if (user_param->raw_qos && user_param->report_min_bw)
+		printf( REPORT_FMT_QOS_MINBW, my_bw_rep->size, my_bw_rep->sl, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg, bw_min);
 	else if (user_param->raw_qos)
 		printf( REPORT_FMT_QOS, my_bw_rep->size, my_bw_rep->sl, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg);
 	else if (user_param->report_per_port)
 		printf(REPORT_FMT_PER_PORT, my_bw_rep->size, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg, bw_avg_p1, msgRate_avg_p1, bw_avg_p2, msgRate_avg_p2);
+	else if (user_param->report_min_bw)
+		printf( inc_accuracy ? REPORT_FMT_EXT_MINBW : REPORT_FMT_MINBW, my_bw_rep->size, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg, bw_min);
 	else
 		printf( inc_accuracy ? REPORT_FMT_EXT : REPORT_FMT, my_bw_rep->size, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg);
 	if (user_param->output == FULL_VERBOSITY) {

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -195,16 +195,20 @@
 #define USEC	"usec"
 /* The format of the results */
 #define RESULT_FMT		" #bytes     #iterations    BW peak[MiB/sec]    BW average[MiB/sec]   MsgRate[Mpps]"
+#define RESULT_FMT_MINBW		" #bytes     #iterations    BW peak[MiB/sec]    BW average[MiB/sec]   MsgRate[Mpps]       BW min[MiB/sec]"
 
 #define RESULT_FMT_PER_PORT	" #bytes     #iterations    BW peak[MiB/sec]    BW average[MiB/sec]   MsgRate[Mpps]   BW Port1[MiB/sec]   MsgRate Port1[Mpps]   BW Port2[MiB/sec]   MsgRate Port2[Mpps]"
 
 #define RESULT_FMT_G	" #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]"
+#define RESULT_FMT_G_MINBW	" #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]        BW min[Gb/sec]"
 
 #define RESULT_FMT_G_PER_PORT	" #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]   BW Port1[Gb/sec]   MsgRate Port1[Mpps]   BW Port2[Gb/sec]   MsgRate Port2[Mpps]"
 
 #define RESULT_FMT_QOS  " #bytes    #sl      #iterations    BW peak[MiB/sec]    BW average[MiB/sec]   MsgRate[Mpps]"
+#define RESULT_FMT_QOS_MINBW  " #bytes    #sl      #iterations    BW peak[MiB/sec]    BW average[MiB/sec]   MsgRate[Mpps]   BW min[MiB/sec]"
 
 #define RESULT_FMT_G_QOS  " #bytes    #sl      #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]"
+#define RESULT_FMT_G_QOS_MINBW  " #bytes    #sl      #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]    BW min[Gb/sec]"
 
 #define RESULT_FMT_LAT " #bytes #iterations    t_min[usec]    t_max[usec]  t_typical[usec]    t_avg[usec]    t_stdev[usec]   99""%"" percentile[usec]   99.9""%"" percentile[usec] "
 
@@ -219,13 +223,17 @@
 #define RESULT_FMT_FS_RATE_DUR " #flows		fs_avg_time[usec]    	fps[flow per sec]"
 
 /* Result print format */
-#define REPORT_FMT " %-7lu    %-10" PRIu64 "       %-7.2lf            %-7.2lf		     %-7.6lf"
+#define REPORT_FMT " %-7lu    %-10" PRIu64 "       %-7.2lf            %-7.2lf		   %-7.6lf"
+#define REPORT_FMT_MINBW " %-7lu    %-10" PRIu64 "       %-7.2lf            %-7.2lf		   %-7.6lf		  %-7.2lf"
 
 #define REPORT_FMT_JSON "\"MsgSize\": %lu,\n\"n_iterations\": %" PRIu64 ",\n\"BW_peak\": %.2lf,\n\"BW_average\": %.2lf,\n\"MsgRate\": %.6lf"
+#define REPORT_FMT_JSON_MINBW "\"MsgSize\": %lu,\n\"n_iterations\": %" PRIu64 ",\n\"BW_peak\": %.2lf,\n\"BW_average\": %.2lf,\n\"MsgRate\": %.6lf,\n\"BW_min\": %.2lf"
 
 #define REPORT_FMT_EXT " %-7lu    %" PRIu64 "           %-7.6lf            %-7.6lf            %-7.6lf"
+#define REPORT_FMT_EXT_MINBW " %-7lu    %" PRIu64 "           %-7.6lf            %-7.6lf            %-7.6lf		  %-7.2lf"
 
 #define REPORT_FMT_EXT_JSON "\"MsgSize\": %lu,\n\"n_iterations\": %" PRIu64 ",\n\"BW_peak\": %.6lf,\n\"BW_average\": %.6lf,\n\"MsgRate\": %.6lf"
+#define REPORT_FMT_EXT_JSON_MINBW "\"MsgSize\": %lu,\n\"n_iterations\": %" PRIu64 ",\n\"BW_peak\": %.6lf,\n\"BW_average\": %.6lf,\n\"MsgRate\": %.6lf,\n\"BW_min\": %.2lf"
 
 #define REPORT_FMT_PER_PORT     " %-7lu    %-10" PRIu64 "     %-7.2lf            %-7.2lf		   %-7.6lf        %-7.2lf            %-7.6lf              %-7.2lf            %-7.6lf"
 
@@ -236,8 +244,10 @@
 #define REPORT_EXT_CPU_UTIL_JSON ",\n\"CPU_util\": %.2f\n"
 
 #define REPORT_FMT_QOS " %-7lu    %d           %lu           %-7.2lf            %-7.2lf                  %-7.6lf\n"
+#define REPORT_FMT_QOS_MINBW " %-7lu    %d           %lu           %-7.2lf            %-7.2lf                  %-7.6lf	%-7.2lf\n"
 
 #define REPORT_FMT_QOS_JSON "\"MsgSize\": %lu,\nsl: %d,\n\"n_iterations\": %lu,\n\"BW_peak\": %.2lf,\n\"BW_average\": %.2lf,\n \"MsgRate\": %.6lf"
+#define REPORT_FMT_QOS_JSON_MINBW "\"MsgSize\": %lu,\nsl: %d,\n\"n_iterations\": %lu,\n\"BW_peak\": %.2lf,\n\"BW_average\": %.2lf,\n \"MsgRate\": %.6lf,\n\"BW_min\": %.2lf"
 
 /* Result print format for latency tests. */
 #define REPORT_FMT_LAT " %-7lu %" PRIu64 "          %-7.2f        %-7.2f      %-7.2f  	       %-7.2f     	%-7.2f		%-7.2f 		%-7.2f"
@@ -709,6 +719,8 @@ struct perftest_parameters {
 	cpu_set_t			cpu_affinity;     /* CPU mask for affinity */
 	int				numa_node;
 	int				disable_numa;
+	int             report_min_bw;
+	uint64_t             report_min_bw_cycles;
 };
 
 struct report_options {
@@ -728,6 +740,7 @@ struct bw_report_data {
 	double msgRate_avg_p1;
 	double msgRate_avg_p2;
 	int sl;
+	double bw_min;
 };
 
 struct perftest_parameters_negotiate   {

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -4472,6 +4472,7 @@ int run_iter_bw(struct pingpong_context *ctx,struct perftest_parameters *user_pa
 	uintptr_t		primary_send_addr = ctx->sge_list[0].addr;
 	int			address_offset = 0;
 	int			flows_burst_iter = 0;
+	cycles_t    batch_start = 0;
 
 	struct dyn_poll_ctx *dyn_ctx = init_dyn_poll_ctx(user_param);
 	if (!dyn_ctx) {
@@ -4479,6 +4480,7 @@ int run_iter_bw(struct pingpong_context *ctx,struct perftest_parameters *user_pa
 		return FAILURE;
 	}
 
+	uint64_t    batch_ccnt = 0;
 	#ifdef HAVE_IBV_WR_API
 	if (user_param->connection_type != RawEth)
 		ctx_post_send_work_request_func_pointer(ctx, user_param);
@@ -4512,6 +4514,9 @@ int run_iter_bw(struct pingpong_context *ctx,struct perftest_parameters *user_pa
 
 	if (user_param->test_type == ITERATIONS && user_param->noPeak == ON)
 		user_param->tposted[0] = get_cycles();
+
+	if(user_param->report_min_bw)
+		batch_start = get_cycles();
 
 	/* If using rate limiter, calculate gap time between bursts */
 	if (user_param->rate_limit_type == SW_RATE_LIMIT ) {
@@ -4684,6 +4689,16 @@ int run_iter_bw(struct pingpong_context *ctx,struct perftest_parameters *user_pa
 						goto cleaning;
 					}
 
+		}
+		if(user_param->report_min_bw) {
+			if (totccnt >= (user_param->report_min_bw + batch_ccnt) && totscnt >= user_param->report_min_bw) {
+				cycles_t batch_duration = get_cycles() - batch_start;
+				batch_start = get_cycles();
+				batch_ccnt = totccnt;
+				if(batch_duration > user_param->report_min_bw_cycles) {
+					user_param->report_min_bw_cycles = batch_duration;
+				}
+			}
 		}
 	}
 	if (user_param->noPeak == ON && user_param->test_type == ITERATIONS)

--- a/src/raw_ethernet_send_bw.c
+++ b/src/raw_ethernet_send_bw.c
@@ -275,8 +275,12 @@ int main(int argc, char *argv[])
 
 	if (user_param.output == FULL_VERBOSITY) {
 		printf(RESULT_LINE);
-		if (user_param.raw_qos)
+		if (user_param.raw_qos && user_param.report_min_bw)
+			printf((user_param.report_fmt == MBS ? RESULT_FMT_QOS_MINBW : RESULT_FMT_G_QOS_MINBW));
+		else if (user_param.raw_qos)
 			printf((user_param.report_fmt == MBS ? RESULT_FMT_QOS : RESULT_FMT_G_QOS));
+		else if (user_param.report_min_bw)
+			printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
 		else
 			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 		printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));

--- a/src/read_bw.c
+++ b/src/read_bw.c
@@ -250,7 +250,10 @@ int main(int argc, char *argv[])
 		}
 		else {
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			if (user_param.report_min_bw)
+				printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+			else
+				printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 		}
 		printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 	}
@@ -412,14 +415,20 @@ int main(int argc, char *argv[])
 			printf(RESULT_LINE);
 			printf("\n Local results: \n");
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			if (user_param.report_min_bw)
+				printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+			else
+				printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 			print_full_bw_report(&user_param, &my_bw_rep, NULL);
 			printf(RESULT_LINE);
 
 			printf("\n Remote results: \n");
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			if (user_param.report_min_bw)
+				printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+			else
+				printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 			print_full_bw_report(&user_param, &rem_bw_rep, NULL);
 		}

--- a/src/send_bw.c
+++ b/src/send_bw.c
@@ -419,7 +419,10 @@ int main(int argc, char *argv[])
 		}
 		else {
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			if (user_param.report_min_bw)
+				printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+			else
+				printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 		}
 		printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 	}
@@ -537,14 +540,20 @@ int main(int argc, char *argv[])
 			printf(RESULT_LINE);
 			printf("\n Local results: \n");
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			if (user_param.report_min_bw)
+				printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+			else
+				printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 			print_full_bw_report(&user_param, &my_bw_rep, NULL);
 			printf(RESULT_LINE);
 
 			printf("\n Remote results: \n");
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			if (user_param.report_min_bw)
+				printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+			else
+				printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 			print_full_bw_report(&user_param, &rem_bw_rep, NULL);
 		}

--- a/src/write_bw.c
+++ b/src/write_bw.c
@@ -265,7 +265,10 @@ int main(int argc, char *argv[])
 		}
 		else {
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			if (user_param.report_min_bw)
+				printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+			else
+				printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 		}
 
 		printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
@@ -493,14 +496,20 @@ int main(int argc, char *argv[])
 			printf(RESULT_LINE);
 			printf("\n Local results: \n");
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			if (user_param.report_min_bw)
+				printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+			else
+				printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 			print_full_bw_report(&user_param, &my_bw_rep, NULL);
 			printf(RESULT_LINE);
 
 			printf("\n Remote results: \n");
 			printf(RESULT_LINE);
-			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
+			if (user_param.report_min_bw)
+				printf((user_param.report_fmt == MBS ? RESULT_FMT_MINBW : RESULT_FMT_G_MINBW));
+			else
+				printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 			print_full_bw_report(&user_param, &rem_bw_rep, NULL);
 		}


### PR DESCRIPTION
Sample and report the minimum bandwidth measured over X iterations. This is useful to pinpoint intermittently unstable links that wouldn't be seen on the average bandwidth