### PR TITLE
Fix issue with PD deallocation.

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1271,7 +1271,7 @@ int destroy_ctx(struct pingpong_context *ctx,
 		}
 	}
 
-	if (user_param->verb == SEND && user_param->work_rdma_cm == ON && ctx->send_rcredit) {
+	if (ctx->send_rcredit) {
 		if (ibv_dereg_mr(ctx->credit_mr)) {
 			fprintf(stderr, "Failed to deregister send credit MR\n");
 			test_result = 1;


### PR DESCRIPTION
Issue: When send_rcredit flag is set to 1 then credit_mr, ctrl_buf, ctrl_sge_list and ctrl_wr are allocated.
       However all these entities are deallocated under additional conditions, like work_rdma_cm == ON.
       This is not always true, ib_send_bw can be run without rdma cm and that leads to error message during PD deallocation:
       "Failed to deallocate PD - Device or resource busy"

Fix: If send_rcredit flag was used during entities creation it is also used during deallocation without additional conditions.