### PR TITLE
Fix race in non-rdmacm ctx_close_connection()

### DIFF
--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -1810,13 +1810,6 @@ int ctx_close_connection(struct perftest_comm *comm,
 	}
 
 	if (!comm->rdma_params->use_rdma_cm && !comm->rdma_params->work_rdma_cm) {
-
-		if (write(comm->rdma_params->sockfd,"done",sizeof "done") != sizeof "done") {
-			perror(" Client write");
-			fprintf(stderr,"Couldn't write to socket\n");
-			return -1;
-		}
-
 		close(comm->rdma_params->sockfd);
 		return 0;
 	}


### PR DESCRIPTION
When rdmacm is not used, ctx_close_connection() does a handshake and then sends "done" over the socket before closing it. This is racy and can lead to a spurious error:

    HOST A                                  HOST B

    ctx_close_connection()
                                            ctx_close_connection()
      ctx_hand_shake() [ succeeds ]
                                              ctx_hand_shake() [ succeeds ]
                                              write(sockfd, "done")
                                              close(sockfd)

      write(sockfd, "done") <-- fails since HOST B has closed the
                                socket and replies with a TCP RST

Fix this simply by deleting the write(). The ctx_hand_shake() already ensures the two sides are in sync and can proceed to the close().