### PR TITLE
perftest: support set flow_label through env variable FLOW_LABEL

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -544,6 +544,11 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		printf("      --tclass=<value> ");
 		printf(" Set the Traffic Class in GRH (if GRH is in use)\n");
 
+		if (connection_type != RawEth) {
+			printf("      --flow_label=<value> ");
+			printf(" Set the flow_label in GRH (if GRH is in use)\n");
+		}
+
 		if (cuda_memory_supported()) {
 			printf("      --use_cuda=<cuda device id>");
 			printf(" Use CUDA specific device for GPUDirect RDMA testing\n");
@@ -841,6 +846,7 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->mr_per_qp			= 0;
 	user_param->dlid			= 0;
 	user_param->traffic_class		= 0;
+	user_param->flow_label			= 0;
 	user_param->flows			= DEF_FLOWS;
 	user_param->flows_burst			= 1;
 	user_param->perform_warm_up		= 0;
@@ -2819,7 +2825,11 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 					use_hl_flag = 0;
 				}
 				if (flow_label_flag) {
-					CHECK_VALUE_NON_NEGATIVE(user_param->flow_label,int,"flow label",not_int_ptr);
+					CHECK_VALUE(user_param->flow_label,int,"flow label",not_int_ptr);
+					if (user_param->connection_type == RawEth && user_param->flow_label < 0) {
+						fprintf(stderr," flow label must be non-negative for RawEth\n");
+						return FAILURE;
+					}
 					flow_label_flag = 0;
 				}
 				if (retry_count_flag) {

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -2524,6 +2524,7 @@ static int ctx_modify_qp_to_rtr(struct ibv_qp *qp,
 			attr->ah_attr.grh.sgid_index = (attr->ah_attr.port_num == user_param->ib_port) ? user_param->gid_index : user_param->gid_index2;
 			attr->ah_attr.grh.hop_limit = 0xFF;
 			attr->ah_attr.grh.traffic_class = user_param->traffic_class;
+			attr->ah_attr.grh.flow_label = user_param->flow_label;
 		}
 		if (user_param->connection_type != UD && user_param->connection_type != SRD) {
 			if (user_param->connection_type == DC) {


### PR DESCRIPTION
- What
Add user parameter ```--flow_label=<value>``` to be set by user to affect the udp sport calculation.
- Why
When some customer report the problem while testing under 1) case one: RoCE LAG 2) case two: not back-to-back connected, the udp sport is randomly selected and make the test result unstable. With adding ```--flow_label=<value>``` to set the grh ```flow_label``` value, it can be used to afftect the udp sport to 1) use same tx port for traffic 2) walk through same traffic path between different round of test when the cards are connected with using switches.