### PR TITLE
Error out if CuDeviceGetByPCIBusId fails

### DIFF
--- a/src/cuda_memory.c
+++ b/src/cuda_memory.c
@@ -117,7 +117,7 @@ int cuda_memory_init(struct memory_ctx *ctx) {
 		printf("Finding PCIe BUS %s\n", cuda_ctx->device_bus_id);
 		err = cuDeviceGetByPCIBusId(&cuda_ctx->device_id, cuda_ctx->device_bus_id);
 		if (err != 0) {
-			fprintf(stderr, "No such PCI Bus Id (%s) exists in system; cuDeviceGetByPCIBusId error: %d\n", cuda_ctx->device_bus_id, err);
+			fprintf(stderr, "cuDeviceGetByPCIBusId failed with error: %d; Failed to get PCI Bus ID (%s)\n", err, cuda_ctx->device_bus_id);
 			return FAILURE;
 		}
 		printf("Picking GPU number %d\n", cuda_ctx->device_id);

--- a/src/cuda_memory.c
+++ b/src/cuda_memory.c
@@ -117,7 +117,8 @@ int cuda_memory_init(struct memory_ctx *ctx) {
 		printf("Finding PCIe BUS %s\n", cuda_ctx->device_bus_id);
 		err = cuDeviceGetByPCIBusId(&cuda_ctx->device_id, cuda_ctx->device_bus_id);
 		if (err != 0) {
-			fprintf(stderr, "We have an error from cuDeviceGetByPCIBusId: %d\n", err);
+			fprintf(stderr, "No such PCI Bus Id (%s) exists in system; cuDeviceGetByPCIBusId error: %d\n", cuda_ctx->device_bus_id, err);
+			return FAILURE;
 		}
 		printf("Picking GPU number %d\n", cuda_ctx->device_id);
 	}


### PR DESCRIPTION
Update cuda_memory_init to error out if CuDeviceGetByPCIBusId fails. Otherwise, it will silently pick up device 0 (ie, value taken from perftest_parameters which is memset to 0 initially).