### PR TITLE
Fix output of error messages

### DIFF
--- a/encrypt_credentials.c
+++ b/encrypt_credentials.c
@@ -127,7 +127,7 @@ int main (int argc , char** argv)
 	encrypted_credentials = fopen(argv[3], "w");
 
 	if(encrypted_credentials == NULL) {
-		printf("Couldn't open the encrypted credentials file");
+		printf("Couldn't open the encrypted credentials file\n");
 		exit(1);
 	}
 

--- a/encrypt_credentials.c
+++ b/encrypt_credentials.c
@@ -127,7 +127,7 @@ int main (int argc , char** argv)
 	encrypted_credentials = fopen(argv[3], "w");
 
 	if(encrypted_credentials == NULL) {
-		printf("Couldn't open the encrypted credentials file\n");
+		fprintf(stderr, "Couldn't open the encrypted credentials file\n");
 		exit(1);
 	}
 

--- a/gen_data_enc_key.c
+++ b/gen_data_enc_key.c
@@ -53,7 +53,7 @@ int encrypt(unsigned char *plaintext, int plaintext_len, unsigned char *kek,
 int main (int argc , char** argv)
 {
 	if(argc != 3){
-		fprintf(stderr, "The application should get 3 parameters");
+		fprintf(stderr, "The application should get 3 parameters\n");
 		exit(1);
 	}
 	/* A 128 bit kek */
@@ -85,7 +85,7 @@ int main (int argc , char** argv)
 	kek_file = fopen(argv[1] , "r");
 
 	if(kek_file == NULL){
-		fprintf(stderr, "Couldn't open key encryption key file");
+		fprintf(stderr, "Couldn't open key encryption key file\n");
 		exit(1);
 	}
 

--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -1409,7 +1409,7 @@ int establish_connection(struct perftest_comm *comm)
 		ptr = comm->rdma_params->servername ? &ethernet_client_connect : &ethernet_server_connect;
 
 		if ((*ptr)(comm)) {
-			fprintf(stderr,"Unable to open file descriptor for socket connection");
+			fprintf(stderr,"Unable to open file descriptor for socket connection\n");
 			return 1;
 		}
 	}

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -694,7 +694,7 @@ static int ctx_xrcd_create(struct pingpong_context *ctx,struct perftest_paramete
 
 	ctx->fd = open(tmp_file_name, O_RDONLY | O_CREAT, S_IRUSR | S_IRGRP);
 	if (ctx->fd < 0) {
-		fprintf(stderr,"Error opening file %s errno: %s", tmp_file_name,strerror(errno));
+		fprintf(stderr,"Error opening file %s errno: %s\n", tmp_file_name,strerror(errno));
 		return FAILURE;
 	}
 
@@ -3629,7 +3629,7 @@ int run_iter_bw_server(struct pingpong_context *ctx, struct perftest_parameters 
 
 		if (user_param->use_event) {
 			if (ctx_notify_events(ctx->recv_channel)) {
-				fprintf(stderr ," Failed to notify events to CQ");
+				fprintf(stderr ," Failed to notify events to CQ\n");
 				return_value = FAILURE;
 				goto cleaning;
 			}
@@ -4613,7 +4613,7 @@ int run_iter_lat_send(struct pingpong_context *ctx,struct perftest_parameters *u
 		if ((rcnt < user_param->iters || user_param->test_type == DURATION) && !(scnt < 1 && user_param->machine == CLIENT)) {
 			if (user_param->use_event) {
 				if (ctx_notify_events(ctx->recv_channel)) {
-					fprintf(stderr , " Failed to notify events to CQ");
+					fprintf(stderr , " Failed to notify events to CQ\n");
 					return 1;
 				}
 			}

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -787,13 +787,13 @@ static __inline int ctx_notify_send_recv_events(struct pingpong_context *ctx)
 
 	if (FD_ISSET(ctx->recv_channel->fd, &rfds) &&
 	    ctx_notify_events(ctx->recv_channel)) {
-		fprintf(stderr,"Failed to notify receive events to CQ");
+		fprintf(stderr,"Failed to notify receive events to CQ\n");
 		return FAILURE;
 	}
 
 	if (FD_ISSET(ctx->send_channel->fd, &rfds) &&
 	    ctx_notify_events(ctx->send_channel)) {
-		fprintf(stderr,"Failed to notify send events to CQ");
+		fprintf(stderr,"Failed to notify send events to CQ\n");
 		return FAILURE;
 	}
 

--- a/src/send_bw.c
+++ b/src/send_bw.c
@@ -106,7 +106,7 @@ static int send_set_up_connection(struct pingpong_context *ctx,
 
 		for (i=0; i < user_param->num_of_qps; i++) {
 			if (ibv_attach_mcast(ctx->qp[i],&mcg_params->mgid,mcg_params->mlid)) {
-				fprintf(stderr, "Couldn't attach QP to MultiCast group");
+				fprintf(stderr, "Couldn't attach QP to MultiCast group\n");
 				return FAILURE;
 			}
 		}
@@ -133,7 +133,7 @@ static int send_destroy_ctx(
 			int i;
 			for (i=0; i < user_param->num_of_qps; i++) {
 				if (ibv_detach_mcast(ctx->qp[i],&mcg_params->mgid,mcg_params->mlid)) {
-					fprintf(stderr, "Couldn't attach QP to MultiCast group");
+					fprintf(stderr, "Couldn't attach QP to MultiCast group\n");
 					return FAILURE;
 				}
 			}

--- a/src/send_lat.c
+++ b/src/send_lat.c
@@ -112,7 +112,7 @@ static int send_set_up_connection(struct pingpong_context *ctx,
 
 		for (i=0; i < user_param->num_of_qps; i++) {
 			if (ibv_attach_mcast(ctx->qp[i],&mcg_params->mgid,mcg_params->mlid)) {
-				fprintf(stderr, "Couldn't attach QP to MultiCast group");
+				fprintf(stderr, "Couldn't attach QP to MultiCast group\n");
 				return FAILURE;
 			}
 		}


### PR DESCRIPTION
I found some error messages are printed like this:

```
# ib_write_bw -d rocep133s0f0 192.168.125.211
Couldn't connect to 192.168.125.211:18515
Unable to open file descriptor for socket connection Unable to init the socket connection
```


The patches fix the output.