### PR TITLE
Update perftest_resources.c

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1788,8 +1788,6 @@ int create_mr(struct pingpong_context *ctx, struct perftest_parameters *user_par
 			}
 			mr_index++;
 		} else {
-			ALLOCATE(ctx->mr[i], struct ibv_mr, 1);
-			memset(ctx->mr[i], 0, sizeof(struct ibv_mr));
 			ctx->mr[i] = ctx->mr[0];
 			// cppcheck-suppress arithOperationsOnVoidPointer
 			ctx->buf[i] = ctx->buf[0] + (i*BUFF_SIZE(ctx->size, ctx->cycle_buffer));


### PR DESCRIPTION
avoid unnecessary memory allocation when  "mr_per_qp"  flag is not set