### PR TITLE
Fix Neuron dmabuf uninitialized offset

### DIFF
--- a/src/neuron_memory.c
+++ b/src/neuron_memory.c
@@ -101,6 +101,8 @@ int neuron_memory_allocate_buffer(struct memory_ctx *ctx, int alignment, uint64_
 			printf("Unable to retrieve dmabuf fd of Neuron device buffer\n");
 			return FAILURE;
 		}
+
+		*dmabuf_offset = 0;
 	}
 
 	neuron_ctx->num_of_tensors++;


### PR DESCRIPTION
Neuron allocated memory is always aligned and the offset relative to fd is 0. Explicitly set it to 0 to avoid use of uninitialized variable in MR registration.