### PR TITLE
Display 'N/A' for peak BW instead of '0' when it's not available

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -3749,10 +3749,17 @@ static void write_bw_report_to_file(int out_json_fd, struct perftest_parameters 
 	else if (user_param->output == OUTPUT_MR)
 		dprintf(out_json_fd, "msgRate_avg: %lf,\n", msgRate_avg);
 	else if (user_param->raw_qos)
-		dprintf(out_json_fd, REPORT_FMT_QOS_JSON, size, sl, iters, bw_peak, bw_avg, msgRate_avg);
+		if (user_param->noPeak)
+			dprintf(out_json_fd, REPORT_FMT_QOS_JSON_NOPEAK, size, sl, iters, bw_avg, msgRate_avg);
+		else
+			dprintf(out_json_fd, REPORT_FMT_QOS_JSON, size, sl, iters, bw_peak, bw_avg, msgRate_avg);
 	else
-		dprintf(out_json_fd, inc_accuracy ? REPORT_FMT_EXT_JSON : REPORT_FMT_JSON,
-								   size, iters, bw_peak, bw_avg, msgRate_avg);
+		if (user_param->noPeak)
+			dprintf(out_json_fd, inc_accuracy ? REPORT_FMT_EXT_JSON_NOPEAK : REPORT_FMT_JSON_NOPEAK,
+									   size, iters, bw_avg, msgRate_avg);
+		else
+			dprintf(out_json_fd, inc_accuracy ? REPORT_FMT_EXT_JSON : REPORT_FMT_JSON,
+									   size, iters, bw_peak, bw_avg, msgRate_avg);
 
 	dprintf(out_json_fd, user_param->cpu_util_data.enable ?
 							REPORT_EXT_CPU_UTIL_JSON : REPORT_EXT_JSON, calc_cpu_util(user_param));
@@ -3816,11 +3823,20 @@ void print_full_bw_report (struct perftest_parameters *user_param, struct bw_rep
 	else if (user_param->output == OUTPUT_MR)
 		printf("%lf\n",msgRate_avg);
 	else if (user_param->raw_qos)
-		printf( REPORT_FMT_QOS, my_bw_rep->size, my_bw_rep->sl, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg);
+		if (user_param->noPeak)
+			printf( REPORT_FMT_QOS_NOPEAK, my_bw_rep->size, my_bw_rep->sl, my_bw_rep->iters, bw_avg, msgRate_avg);
+		else
+			printf( REPORT_FMT_QOS, my_bw_rep->size, my_bw_rep->sl, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg);
 	else if (user_param->report_per_port)
-		printf(REPORT_FMT_PER_PORT, my_bw_rep->size, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg, bw_avg_p1, msgRate_avg_p1, bw_avg_p2, msgRate_avg_p2);
+		if (user_param->noPeak)
+			printf(REPORT_FMT_PER_PORT_NOPEAK, my_bw_rep->size, my_bw_rep->iters, bw_avg, msgRate_avg, bw_avg_p1, msgRate_avg_p1, bw_avg_p2, msgRate_avg_p2);
+		else
+			printf(REPORT_FMT_PER_PORT, my_bw_rep->size, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg, bw_avg_p1, msgRate_avg_p1, bw_avg_p2, msgRate_avg_p2);
 	else
-		printf( inc_accuracy ? REPORT_FMT_EXT : REPORT_FMT, my_bw_rep->size, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg);
+		if (user_param->noPeak)
+			printf( inc_accuracy ? REPORT_FMT_EXT_NOPEAK : REPORT_FMT_NOPEAK, my_bw_rep->size, my_bw_rep->iters, bw_avg, msgRate_avg);
+		else
+			printf( inc_accuracy ? REPORT_FMT_EXT : REPORT_FMT, my_bw_rep->size, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg);
 	if (user_param->output == FULL_VERBOSITY) {
 		fflush(stdout);
 		fprintf(stdout, user_param->cpu_util_data.enable ? REPORT_EXT_CPU_UTIL : REPORT_EXT , calc_cpu_util(user_param));

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -237,6 +237,14 @@
 
 #define REPORT_FMT_QOS_JSON "MsgSize: %lu,\nsl: %d,\nn_iterations: %lu,\nBW_peak: %.2lf,\nBW_average: %.2lf,\n MsgRate: %.6lf,\n"
 
+#define REPORT_FMT_NOPEAK " %-7lu    %-10" PRIu64 "     N/A                %-7.2lf		   %-7.6lf"
+#define REPORT_FMT_JSON_NOPEAK "MsgSize: %lu,\nn_iterations: %" PRIu64 ",\nBW_peak: \"N/A\",\nBW_average: %.2lf,\nMsgRate: %.6lf,\n"
+#define REPORT_FMT_EXT_NOPEAK " %-7lu    %" PRIu64 "         N/A                %-7.6lf            %-7.6lf"
+#define REPORT_FMT_EXT_JSON_NOPEAK "MsgSize: %lu,\nn_iterations: %" PRIu64 ",\nBW_peak: \"N/A\",\nBW_average: %.6lf,\nMsgRate: %.6lf,\n"
+#define REPORT_FMT_PER_PORT_NOPEAK     " %-7lu    %-10" PRIu64 "   N/A                %-7.2lf		   %-7.6lf        %-7.2lf            %-7.6lf              %-7.2lf            %-7.6lf"
+#define REPORT_FMT_QOS_NOPEAK " %-7lu    %d           %lu         N/A                %-7.2lf                  %-7.6lf\n"
+#define REPORT_FMT_QOS_JSON_NOPEAK "MsgSize: %lu,\nsl: %d,\nn_iterations: %lu,\nBW_peak: \"N/A\",\nBW_average: %.2lf,\n MsgRate: %.6lf,\n"
+
 /* Result print format for latency tests. */
 #define REPORT_FMT_LAT " %-7lu %" PRIu64 "          %-7.2f        %-7.2f      %-7.2f  	       %-7.2f     	%-7.2f		%-7.2f 		%-7.2f"
 


### PR DESCRIPTION
The display of 0 peak BW is confusing, especially when the user does not choose to run without peak-bw explicitly, but for example runs with '-D'. In such cases peak-bw calculatiuon is disabled internally, and the zero result is confusing, and makes the user assume that something went wrong during the run. If the value is not calculated, it shouldn't be numeric.