### PR TITLE
perftest: Add Broadcom gen p7 adapter device ids

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1909,6 +1909,8 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 			case 5872  : dev_fname = NETXTREME; break;
 			case 5873  : dev_fname = NETXTREME; break;
 			case 5968  : dev_fname = NETXTREME; break;
+			case 5984 : dev_fname = NETXTREME; break;
+			case 6169 : dev_fname = NETXTREME; break;
 			case 55296 : dev_fname = NETXTREME; break;
 			case 55298 : dev_fname = NETXTREME; break;
 			case 55300 : dev_fname = NETXTREME; break;


### PR DESCRIPTION
Add the device ids for Gen P7 adapter.