### PR TITLE
Add support for loongarch64.

### DIFF
--- a/src/get_clock.c
+++ b/src/get_clock.c
@@ -155,6 +155,9 @@ static double proc_get_cpu_mhz(int no_cpu_freq_warn)
 		#if defined (__ia64__)
 		/* Use the ITC frequency on IA64 */
 		rc = sscanf(buf, "itc MHz : %lf", &m);
+		#elif defined (__loongarch__)
+		/* Use upper case cpu on LoongArch */
+		rc = sscanf(buf, "CPU MHz : %lf", &m);
 		#elif defined (__PPC__) || defined (__PPC64__)
 		/* PPC has a different format as well */
 		rc = sscanf(buf, "clock : %lf", &m);

--- a/src/get_clock.h
+++ b/src/get_clock.h
@@ -104,6 +104,16 @@ static inline cycles_t get_cycles()
 	asm volatile("mrs %0, cntvct_el0" : "=r" (cval));
 	return cval;
 }
+#elif defined(__loongarch_lp64)
+
+typedef unsigned long cycles_t;
+
+static inline cycles_t get_cycles()
+{
+        cycles_t cval;
+        __asm__ __volatile__("rdtime.d %0, $zero" : "=r"(cval));
+        return cval;
+}
 #elif defined(__riscv)
 typedef unsigned long cycles_t;
 


### PR DESCRIPTION
Please review it, the test result as follow:

$uname -a
Linux test-3a6000 6.7.0-rc2-2 #1 SMP PREEMPT Mon, 27 Nov 2023 08:42:49 +0000 loongarch64 GNU/Linux
$gcc clock_test.c get_clock.c -o clock_test
$./clock_test 
Type CTRL-C to cancel.
1 sec = 1.00011e+06 usec
1 sec = 1.00011e+06 usec
1 sec = 1.00011e+06 usec
^C
$
