### PR TITLE
add support for ROCm6.0 API changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,6 +245,8 @@ AS_IF([test "x$enable_rocm" = xyes], [
        AC_DEFINE([__HIP_PLATFORM_AMD__], [1], [Enable ROCm])
        AC_CHECK_HEADERS([hip/hip_runtime_api.h], [],
                         [AC_MSG_ERROR([cannot include hip/hip_runtime_api.h])])
+       AC_CHECK_HEADERS([hip/hip_version.h], [],
+                        [AC_MSG_ERROR([cannot include hip_version.h])])
        AC_SEARCH_LIBS([hipFree], [amdhip64], [],
                       [AC_MSG_ERROR([cannot link with -lamdhip64])])
        AC_DEFINE([HAVE_ROCM], [1], [Enable ROCm])

--- a/configure.ac
+++ b/configure.ac
@@ -242,7 +242,7 @@ AC_ARG_WITH([rocm],
             ])
 
 AS_IF([test "x$enable_rocm" = xyes], [
-       AC_DEFINE([__HIP_PLATFORM_HCC__], [1], [Enable ROCm])
+       AC_DEFINE([__HIP_PLATFORM_AMD__], [1], [Enable ROCm])
        AC_CHECK_HEADERS([hip/hip_runtime_api.h], [],
                         [AC_MSG_ERROR([cannot include hip/hip_runtime_api.h])])
        AC_SEARCH_LIBS([hipFree], [amdhip64], [],

--- a/src/rocm_memory.c
+++ b/src/rocm_memory.c
@@ -8,7 +8,9 @@
 #include <errno.h>
 #include "rocm_memory.h"
 #include <hip/hip_runtime_api.h>
+#if defined HAVE_HIP_HIP_VERSION_H
 #include <hip/hip_version.h>
+#endif
 #include "perftest_parameters.h"
 
 #define ROCM_CHECK(stmt)			\
@@ -45,13 +47,18 @@ static int init_rocm(int device_id) {
 
 	hipDeviceProp_t prop = {0};
 	ROCM_CHECK(hipGetDeviceProperties(&prop, device_id));
+
+	/* Need 256 bytes to silence compiler warning */
+	char archName[256];
 #if HIP_VERSION >= 60000000
-	printf("Using ROCm Device with ID: %d, Name: %s, PCI Bus ID: 0x%x, GCN Arch: %s\n",
-	       device_id, prop.name, prop.pciBusID, prop.gcnArchName);
+	snprintf(archName, 256, "%s", prop.gcnArchName);
 #else
-	printf("Using ROCm Device with ID: %d, Name: %s, PCI Bus ID: 0x%x, GCN Arch: %d\n",
-	       device_id, prop.name, prop.pciBusID, prop.gcnArch);
+	snprintf(archName, 256, "%d", prop.gcnArch);
 #endif
+
+	printf("Using ROCm Device with ID: %d, Name: %s, PCI Bus ID: 0x%x, GCN Arch: %s\n",
+	       device_id, prop.name, prop.pciBusID, archName);
+
 	return SUCCESS;
 }
 

--- a/src/rocm_memory.c
+++ b/src/rocm_memory.c
@@ -6,8 +6,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <hip/hip_runtime_api.h>
 #include "rocm_memory.h"
+#include <hip/hip_runtime_api.h>
+#include <hip/hip_version.h>
 #include "perftest_parameters.h"
 
 #define ROCM_CHECK(stmt)			\
@@ -44,9 +45,13 @@ static int init_rocm(int device_id) {
 
 	hipDeviceProp_t prop = {0};
 	ROCM_CHECK(hipGetDeviceProperties(&prop, device_id));
+#if HIP_VERSION >= 60000000
+	printf("Using ROCm Device with ID: %d, Name: %s, PCI Bus ID: 0x%x, GCN Arch: %s\n",
+	       device_id, prop.name, prop.pciBusID, prop.gcnArchName);
+#else
 	printf("Using ROCm Device with ID: %d, Name: %s, PCI Bus ID: 0x%x, GCN Arch: %d\n",
 	       device_id, prop.name, prop.pciBusID, prop.gcnArch);
-
+#endif
 	return SUCCESS;
 }
 


### PR DESCRIPTION
perftest fails to compile with ROCm 6.0 due to some backward incompatible changes (resp. deprecations). This commit ensure support for ROCm 4.x, 5.x and 6.x for perftest