### PR TITLE
Fixes RDMA CM connection error during asynchronous rdma_disconnect 

### DIFF
--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -2633,10 +2633,12 @@ int rdma_cm_disconnect_nodes(struct pingpong_context *ctx,
 		}
 
 		ctx->cma_master.nodes[i].connected = 0;
-		rc = rdma_disconnect(ctx->cma_master.nodes[i].cma_id);
-		if (rc) {
-			error_message = "Failed to disconnect RDMA CM connection.";
-			goto error;
+		if (user_param->machine == SERVER) {
+			rc = rdma_disconnect(ctx->cma_master.nodes[i].cma_id);
+			if (rc) {
+				error_message = "Failed to disconnect RDMA CM connection.";
+				goto error;
+			}
 		}
 	}
 	while (ctx->cma_master.disconnects_left) {


### PR DESCRIPTION
In working case both the server and client call rdma_disconnect() synchronously, When the server is calling rdma_disconnect, the server's qp  state changes from RTS to closing and sends FIN to the client. On the client side, peer_close will change the qp state from closing to closing, and  close_con_rpl will change the qp state from closing to idle. The client also calls rdma_disconnect. As a result, the client's qp state changes from RTS to closing and sends FIN to the server, and at the server side, peer_close will change the qp state from closing to closing, and close_con_rpl will change the qp state from closing to idle.

But in write_lat, the client calls rdma_disconnect before the server calls rdma_disconnect, and the client qp state will change from idle to closing and it will send FIN to the server, and on the server side, peer_close will change the qp state from RTS to closing and close_con_rpl will change the qp state from closing to idle. Now that the server qp state is idle, the server is calling rdma_disconnect and trying to change the server qp state from idle to closing, but this is not allowed, which results in an RDMA CM connection error.

This patch fixes the issue by calling rdma-disconnect only by server, so no need to worry about asynchronously calling of rdma-disconnect.

Fixes #233 