### PR TITLE
Fix out-of-tree man page build when top_srcdir is an absolute path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,7 +76,13 @@ dist_man_MANS = man/perftest.1
 
 generated_mans = $(man1_MANS)
 $(generated_mans): $(top_builddir)/man/%.1: man/perftest.1
-	ln -s ../$(top_srcdir)/man/perftest.1 $@
+	@if echo $(top_srcdir) | grep '^/' > /dev/null ; then \
+	  echo ln -s $(top_srcdir)/man/perftest.1 $@ ; \
+	  ln -s $(top_srcdir)/man/perftest.1 $@ ; \
+	else \
+	  echo ln -s ../$(top_srcdir)/man/perftest.1 $@ ; \
+	  ln -s ../$(top_srcdir)/man/perftest.1 $@ ; \
+	fi
 
 clean-local:
 	-rm -f man/[ir]*.1


### PR DESCRIPTION
Commit 248d1b74 only fixed out-of-tree man page builds when top_srcdir is a relative path.  The configure script uses $0 to set top_srcdir, so if configure is run with an absolute path then top_srcdir will be an absolute path too (e.g. "../configure" sets top_srcdir to ".." while "/path/to/configure" sets top_srcdir to "/path/to").

Update the "ln -s" command that sets up man page links in Makefile.am to handle the case where top_srcdir is an absolute path.