### PR TITLE
Correct build requirement names

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,8 +61,8 @@ AC_PROG_RANLIB
 AC_HEADER_STDC
 AC_CHECK_HEADERS([infiniband/verbs.h],,[AC_MSG_ERROR([ibverbs header files not found])])
 AC_CHECK_LIB([ibverbs], [ibv_get_device_list], [], [AC_MSG_ERROR([libibverbs not found])])
-AC_CHECK_LIB([rdmacm], [rdma_create_event_channel], [], AC_MSG_ERROR([librdmacm-devel not found]))
-AC_CHECK_LIB([ibumad], [umad_init], [LIBUMAD=-libumad], AC_MSG_ERROR([libibumad not found]))
+AC_CHECK_LIB([rdmacm], [rdma_create_event_channel], [], AC_MSG_ERROR([librdmacm-dev not found]))
+AC_CHECK_LIB([ibumad], [umad_init], [LIBUMAD=-libumad], AC_MSG_ERROR([libibumad-dev not found]))
 AC_CHECK_LIB([m], [log], [LIBMATH=-lm], AC_MSG_ERROR([libm not found]))
 
 AC_CHECK_LIB([ibverbs], [ibv_reg_dmabuf_mr], [HAVE_REG_DMABUF_MR=yes], [HAVE_REG_DMABUF_MR=no])
@@ -203,7 +203,7 @@ if [test $HAVE_SNIFFER = yes]; then
 fi
 
 if [test $IS_FREEBSD = no]; then
-	AC_CHECK_HEADERS([pci/pci.h],,[AC_MSG_ERROR([pciutils header files not found, consider installing pciutils-devel])])
+	AC_CHECK_HEADERS([pci/pci.h],,[AC_MSG_ERROR([pciutils header files not found, consider installing libpci-dev])])
 	AC_CHECK_LIB([pci], [pci_init], [LIBPCI=-lpci], AC_MSG_ERROR([libpci not found]))
 	CPU_IS_RO_COMPLIANT=yes
 fi

--- a/perftest.spec
+++ b/perftest.spec
@@ -7,8 +7,8 @@ Group:          Productivity/Networking/Diagnostic
 Source:         http://www.openfabrics.org/downloads/%{name}-%{version}.tar.gz
 Url:            http://www.openfabrics.org
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildRequires:  libibverbs-devel librdmacm-devel libibumad-devel
-BuildRequires:  pciutils-devel
+BuildRequires:  libibverbs-dev librdmacm-dev libibumad-dev
+BuildRequires:  libpci-dev
 
 %description
 gen3 uverbs microbenchmarks


### PR DESCRIPTION
Use proper debian package names to display when missing packages at buildtime
- librdmacm-devel -> librdmacm-dev
- libibumad -> libibumad-dev
- pciutils-devel -> libpci-dev