### PR TITLE
Fix syntax of script run_perftest_loopback

### DIFF
--- a/run_perftest_loopback
+++ b/run_perftest_loopback
@@ -2,7 +2,7 @@
 # trivial script to launch a loopback test on the same device
 # example: run_perftest_loopback 0 1 ib_write_bw -s 10
 os_type=$(uname)
-if [ $os_type == "FreeBSD" ]; then
+if [ "$os_type" = "FreeBSD" ]; then
 	cpu_bind_cmd="cpuset -l"
 else 
 	cpu_bind_cmd="taskset -c"
@@ -17,11 +17,11 @@ server_core=$1
 client_core=$2
 shift 2
 
-$cpu_bind_cmd $server_core $* &
+$cpu_bind_cmd $server_core "$@" &
 #give server time to start
 sleep 1
 
-$cpu_bind_cmd  $client_core $* localhost
+$cpu_bind_cmd  $client_core "$@" localhost
 
 status=$?
 


### PR DESCRIPTION
Allow using a command line that has quotes and such.