### PR TITLE
Perftest: Fix rx_depth check for XRC

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1124,7 +1124,19 @@ static void force_dependecies(struct perftest_parameters *user_param)
 		exit (1);
 	}
 
-	if (user_param->use_srq && user_param->num_of_qps > user_param->rx_depth) {
+	/* XRC Part */
+	if (user_param->connection_type == XRC) {
+		if (user_param->work_rdma_cm == ON) {
+			printf(RESULT_LINE);
+			fprintf(stderr," XRC does not support RDMA_CM\n");
+			exit(1);
+		}
+		user_param->use_xrc = ON;
+		user_param->use_srq = ON;
+	}
+
+	if (user_param->use_srq && user_param->verb == SEND &&
+	    user_param->num_of_qps > user_param->rx_depth) {
 		printf(RESULT_LINE);
 		printf(" Using SRQ depth should be greater than number of QPs.\n");
 		exit (1);
@@ -1418,17 +1430,6 @@ static void force_dependecies(struct perftest_parameters *user_param)
 
 	if (user_param->connection_type == DC && !user_param->use_srq)
 		user_param->use_srq = ON;
-
-	/* XRC Part */
-	if (user_param->connection_type == XRC) {
-		if (user_param->work_rdma_cm == ON) {
-			printf(RESULT_LINE);
-			fprintf(stderr," XRC does not support RDMA_CM\n");
-			exit(1);
-		}
-		user_param->use_xrc = ON;
-		user_param->use_srq = ON;
-	}
 
 	if (!user_param->use_old_post_send)
 	{


### PR DESCRIPTION
When users manually specifies --use_srq in perftest command, the rx_depth will be checked. If rx_depth is less than the number of qps, the process will throw an error and exit.

For XRC SEND where SRQ is definitely used, users normally don't need to manually specifies --use_srq, since the use_srq flag will be set to on when parsing the XRC parameters. However, the XRC parameters parsing is after the SRQ rx_depth check. If rx_depth is less than the number of qps in this case, it will miss the check, size_per_qp in ctx_set_recv_wqes() will become 0 and ibv_post_srq_recv() won't be called.

Move the XRC parameters parsing ahead of SRQ rx_depth check and set --use_srq to on in advance so that the rx_depth error can be thrown.

Fixes: 4c774a951b3c ("Added XRC for ib_send_bw test")