### PR TITLE
Add support for SRD unsolicited write w/ imm. receive

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -393,6 +393,11 @@ if [test $HAVE_IBV_WR_API = yes]; then
 	if [test $HAVE_RDMA_WRITE_SRD = yes]; then
 		AC_DEFINE([HAVE_SRD_WITH_RDMA_WRITE], [1], [Have SRD with RDMA write support])
 	fi
+	AC_TRY_LINK([#include <infiniband/efadv.h>],
+		    [int x = EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV;], [HAVE_UNSOLICITED_WRITE_RECV_SRD=yes], [HAVE_UNSOLICITED_WRITE_RECV_SRD=no])
+	if [test $HAVE_UNSOLICITED_WRITE_RECV_SRD = yes]; then
+		AC_DEFINE([HAVE_SRD_WITH_UNSOLICITED_WRITE_RECV], [1], [Have SRD with unsolicited RDMA write with imm. support])
+	fi
 else
 	AC_CHECK_LIB([efa], [efadv_create_driver_qp], [HAVE_SRD=yes], [HAVE_SRD=no])
 fi

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -639,6 +639,7 @@ struct perftest_parameters {
 	int 				has_source_ip;
 	int 			ah_allocated;
 	int				use_write_with_imm;
+	int				use_unsolicited_write;
 };
 
 struct report_options {

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -2431,6 +2431,10 @@ struct ibv_qp* ctx_qp_create(struct pingpong_context *ctx,
 		#ifdef HAVE_SRD
 		#ifdef HAVE_IBV_WR_API
 		efa_attr.driver_qp_type = EFADV_QP_DRIVER_TYPE_SRD;
+		#ifdef HAVE_SRD_WITH_UNSOLICITED_WRITE_RECV
+		if (user_param->use_unsolicited_write)
+			efa_attr.flags |= EFADV_QP_FLAGS_UNSOLICITED_WRITE_RECV;
+		#endif
 		qp = efadv_create_qp_ex(ctx->context, &attr_ex,
 					&efa_attr, sizeof(efa_attr));
 		#else
@@ -3797,7 +3801,7 @@ int run_iter_bw_server(struct pingpong_context *ctx, struct perftest_parameters 
 					}
 					//coverity[uninit_use]
 					if ((user_param->test_type==DURATION || posted_per_qp[wc_id] + user_param->recv_post_list <= user_param->iters) &&
-							unused_recv_for_qp[wc_id] >= user_param->recv_post_list) {
+					    unused_recv_for_qp[wc_id] >= user_param->recv_post_list && !user_param->use_unsolicited_write) {
 						if (user_param->use_srq) {
 							if (ibv_post_srq_recv(ctx->srq, &ctx->rwr[wc_id * user_param->recv_post_list], &bad_wr_recv)) {
 								fprintf(stderr, "Couldn't post recv SRQ. QP = %d: counter=%lu\n", wc_id,rcnt);
@@ -4084,7 +4088,7 @@ int run_iter_bw_infinitely_server(struct pingpong_context *ctx, struct perftest_
 				}
 				user_param->iters++;
 				unused_recv_for_qp[wc[i].wr_id]++;
-				if (unused_recv_for_qp[wc[i].wr_id] >= user_param->recv_post_list) {
+				if (unused_recv_for_qp[wc[i].wr_id] >= user_param->recv_post_list && !user_param->use_unsolicited_write) {
 					if (user_param->use_srq) {
 						if (ibv_post_srq_recv(ctx->srq, &ctx->rwr[wc[i].wr_id * user_param->recv_post_list],&bad_wr_recv)) {
 							fprintf(stderr, "Couldn't post recv SRQ. QP = %d:\n",(int)wc[i].wr_id);
@@ -4338,7 +4342,7 @@ int run_iter_bi(struct pingpong_context *ctx,
 				}
 
 				if ((user_param->test_type==DURATION || posted_per_qp[wc[i].wr_id] + user_param->recv_post_list <= user_param->iters) &&
-						unused_recv_for_qp[wc[i].wr_id] >= user_param->recv_post_list) {
+				    unused_recv_for_qp[wc[i].wr_id] >= user_param->recv_post_list && !user_param->use_unsolicited_write) {
 					if (user_param->use_srq) {
 						if (ibv_post_srq_recv(ctx->srq, &ctx->rwr[wc[i].wr_id * user_param->recv_post_list],&bad_wr_recv)) {
 							fprintf(stderr, "Couldn't post recv SRQ. QP = %d: counter=%d\n",(int)wc[i].wr_id,(int)totrcnt);
@@ -4682,7 +4686,8 @@ int run_iter_lat_write_imm(struct pingpong_context *ctx,struct perftest_paramete
 				 * is enough space in the rx_depth,
 				 * post that you received a packet.
 				 */
-				if (user_param->test_type == DURATION || (rcnt + size_per_qp <= user_param->iters)) {
+				if ((user_param->test_type == DURATION || (rcnt + size_per_qp <= user_param->iters)) &&
+				    !user_param->use_unsolicited_write) {
 					if (user_param->use_srq) {
 						if (ibv_post_srq_recv(ctx->srq, &ctx->rwr[wc.wr_id], &bad_wr_recv)) {
 							fprintf(stderr, "Couldn't post recv SRQ. QP = %d: counter=%lu\n",(int)wc.wr_id, rcnt);

--- a/src/write_bw.c
+++ b/src/write_bw.c
@@ -301,7 +301,8 @@ int main(int argc, char *argv[])
 			if (user_param.machine == CLIENT || user_param.duplex)
 				ctx_set_send_wqes(&ctx,&user_param,rem_dest);
 
-			if (user_param.verb == WRITE_IMM && (user_param.machine == SERVER || user_param.duplex)) {
+			if (user_param.verb == WRITE_IMM && !user_param.use_unsolicited_write &&
+			    (user_param.machine == SERVER || user_param.duplex)) {
 				if (ctx_set_recv_wqes(&ctx,&user_param)) {
 					fprintf(stderr," Failed to post receive recv_wqes\n");
 					goto free_mem;

--- a/src/write_lat.c
+++ b/src/write_lat.c
@@ -262,10 +262,12 @@ int main(int argc, char *argv[])
 			user_param.size = (uint64_t)1 << i;
 
 			if (user_param.verb == WRITE_IMM) {
-				/* Post receive recv_wqes fo current message size */
-				if (ctx_set_recv_wqes(&ctx,&user_param)) {
-					fprintf(stderr," Failed to post receive recv_wqes\n");
-					goto free_mem;
+				if (!user_param.use_unsolicited_write) {
+					/* Post receive recv_wqes fo current message size */
+					if (ctx_set_recv_wqes(&ctx,&user_param)) {
+						fprintf(stderr," Failed to post receive recv_wqes\n");
+						goto free_mem;
+					}
 				}
 
 				/* Sync between the client and server so the client won't send packets


### PR DESCRIPTION
Add a new --unsolicited_write flag, available when using SRD with supporting rdma-core version in write with immediate tests. When used, receive WRs will not be posted.