### PR TITLE
Perftest: Add support for TD lock-free mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -389,6 +389,20 @@ if [test $HAVE_HNSDV = yes]; then
 	AC_SUBST([LIBHNS])
 fi
 
+AC_TRY_LINK([#include <infiniband/verbs.h>],
+	[ibv_cq_ex_to_cq], [HAVE_CQ_EX=yes], [HAVE_CQ_EX=no])
+AM_CONDITIONAL([HAVE_CQ_EX], [test "x$HAVE_CQ_EX" = "xyes"])
+if [test $HAVE_CQ_EX = yes]; then
+	AC_DEFINE([HAVE_CQ_EX], [1], [Have CQ EX API support])
+fi
+
+AC_TRY_LINK([#include <infiniband/verbs.h>],
+	[ibv_alloc_td], [HAVE_TD_API=yes], [HAVE_TD_API=no])
+AM_CONDITIONAL([HAVE_TD_API], [test "x$HAVE_TD_API" = "xyes"])
+if [test $HAVE_TD_API = yes]; then
+	AC_DEFINE([HAVE_TD_API], [1], [Have TD API support])
+fi
+
 CFLAGS="-g -Wall -D_GNU_SOURCE -O3 $CFLAGS"
 LDFLAGS="$LDFLAGS"
 LIBS=$LIBS" -lpthread"

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -466,6 +466,11 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		printf(" Use a Shared Receive Queue. --rx-depth controls max-wr size of the SRQ \n");
 	}
 
+	#ifdef HAVE_TD_API
+	printf("      --no_lock ");
+	printf(" No lock in IO, including post send, post recv, post srq recv and poll cq \n");
+	#endif
+
 	if (connection_type != RawEth) {
 		printf("      --ipv6 ");
 		printf(" Use IPv6 GID. Default is IPv4\n");
@@ -872,6 +877,7 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->has_source_ip	= 0;
 	user_param->use_write_with_imm	= 0;
 	user_param->congest_type	= OFF;
+	user_param->no_lock		= OFF;
 }
 
 static int open_file_write(const char* file_path)
@@ -2326,6 +2332,9 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	#ifdef HAVE_HNSDV
 	static int congest_type_flag = 0;
 	#endif
+	#ifdef HAVE_TD_API
+	static int no_lock_flag = 0;
+	#endif
 
 	char *server_ip = NULL;
 	char *client_ip = NULL;
@@ -2405,6 +2414,9 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{ .name = "run_infinitely",	.has_arg = 0, .flag = &run_inf_flag, .val = 1 },
 			{ .name = "report_gbits",	.has_arg = 0, .flag = &report_fmt_flag, .val = 1},
 			{ .name = "use-srq",		.has_arg = 0, .flag = &srq_flag, .val = 1},
+			#ifdef HAVE_TD_API
+			{ .name = "no_lock",		.has_arg = 0, .flag = &no_lock_flag, .val = 1},
+			#endif
 			{ .name = "use-null-mr",	.has_arg = 0, .flag = &use_null_mr_flag, .val = 1},
 			{ .name = "report-both",	.has_arg = 0, .flag = &report_both_flag, .val = 1},
 			{ .name = "reversed",		.has_arg = 0, .flag = &is_reversed_flag, .val = 1},
@@ -3148,6 +3160,12 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 		user_param->use_srq = 1;
 	}
 
+	#ifdef HAVE_TD_API
+	if (no_lock_flag) {
+		user_param->no_lock = 1;
+	}
+	#endif
+
 	if (use_null_mr_flag) {
 		user_param->use_null_mr = 1;
 	}
@@ -3492,15 +3510,24 @@ void ctx_print_test_info(struct perftest_parameters *user_param)
 	printf(" Number of qps   : %d\t\tTransport type : %s\n", user_param->num_of_qps, transport_str(user_param->transport_type));
 	printf(" Connection type : %s\t\tUsing SRQ      : %s\n", connStr[user_param->connection_type], user_param->use_srq ? "ON"  : "OFF");
 	#ifdef HAVE_RO
-	printf(" PCIe relax order: %s\n", user_param->disable_pcir ? "OFF"  : "ON");
+	#ifdef HAVE_TD_API
+	printf(" PCIe relax order: %s\t\tLock-free      : %s\n", user_param->disable_pcir ? "OFF"  : "ON", user_param->no_lock ? "ON" : "OFF");
+	#else
+	printf(" PCIe relax order: %s\t\tLock-free      : %s\n", user_param->disable_pcir ? "OFF"  : "ON", "Unsupported");
+	#endif //HAVE_TD_API
 	if ((check_pcie_relaxed_ordering_compliant() == false) &&
 	    (user_param->disable_pcir == 0)) {
 		printf(" WARNING: CPU is not PCIe relaxed ordering compliant.\n");
 		printf(" WARNING: You should disable PCIe RO with `--disable_pcie_relaxed` for both server and client.\n");
 	}
 	#else
-	printf(" PCIe relax order: %s\n", "Unsupported");
+	#ifdef HAVE_TD_API
+	printf(" PCIe relax order: %s\t\tLock-free      : %s\n", "Unsupported", user_param->no_lock ? "ON" : "OFF");
+	#else
+	printf(" PCIe relax order: %s\t\tLock-free	: %s\n", "Unsupported", "Unsupported");
+	#endif //HAVE_TD_API
 	#endif
+
 	printf(" ibv_wr* API     : %s\n", user_param->use_old_post_send ? "OFF" : "ON");
 	if (user_param->machine == CLIENT || user_param->duplex) {
 		printf(" TX depth        : %d\n",user_param->tx_depth);

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -524,6 +524,7 @@ struct perftest_parameters {
 	int 				recv_post_list;
 	int				duration;
 	int 				use_srq;
+	int 				no_lock;
 	int 				congest_type;
 	int				use_xrc;
 	int				use_rss;

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -178,6 +178,10 @@ struct pingpong_context {
 	struct ibv_comp_channel			*recv_channel;
 	struct ibv_comp_channel			*send_channel;
 	struct ibv_pd				*pd;
+	#ifdef HAVE_TD_API
+	struct ibv_td				*td;
+	struct ibv_pd				*pad;
+	#endif
 	struct ibv_mr				**mr;
 	struct ibv_mr				*null_mr;
 	struct ibv_cq				*send_cq;


### PR DESCRIPTION
Add support for TD lock-free mode
New option:  --no_lock

        Usage example:
        ./ib_send_bw -d hns_0 --no_lock
        ./ib_send_bw -d hns_0 --no_lock 192.168.100.100