### PR TITLE
perftest: support set flow_label list val in GRH with RR method

### DIFF
--- a/man/perftest.1
+++ b/man/perftest.1
@@ -481,7 +481,7 @@ many different options and modes.
  Not relevant for raw_ethernet_fs_rate.
  System support required.
 .TP
-.B --flow_label
+.B --flow_label=<fl0, fl1,...>
  IPv6 flow label.
  Not relevant for raw_ethernet_fs_rate.
 .TP

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -605,7 +605,7 @@ struct perftest_parameters {
 	char				*out_json_file_name;
 	struct cpu_util_data 		cpu_util_data;
 	int 				latency_gap;
-	int 				flow_label;
+	int*  				flow_label;
 	int 				retry_count;
 	int 				dont_xchg_versions;
 	int 				ipv6;

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -2682,7 +2682,10 @@ static int ctx_modify_qp_to_rtr(struct ibv_qp *qp,
 			attr->ah_attr.grh.sgid_index = (attr->ah_attr.port_num == user_param->ib_port) ? user_param->gid_index : user_param->gid_index2;
 			attr->ah_attr.grh.hop_limit = 0xFF;
 			attr->ah_attr.grh.traffic_class = user_param->traffic_class;
-			attr->ah_attr.grh.flow_label = user_param->flow_label;
+			if (user_param->flow_label) {
+				attr->ah_attr.grh.flow_label = user_param->flow_label[user_param->flow_label[1] % user_param->flow_label[0] + 2];
+				user_param->flow_label[1] = user_param->flow_label[1] + 1;
+			}
 		}
 		if (user_param->connection_type != UD && user_param->connection_type != SRD) {
 			if (user_param->connection_type == DC) {

--- a/src/raw_ethernet_resources.c
+++ b/src/raw_ethernet_resources.c
@@ -732,9 +732,10 @@ static void fill_ip_common(struct ibv_flow_spec* spec_info,
 			}
 			if (user_param->flow_label) {
 				ipv6_spec->val.flow_label =
-					htonl(user_param->flow_label);
+					htonl(user_param->flow_label[user_param->flow_label[1] % user_param->flow_label[0] + 2]);
 				ipv6_spec->mask.flow_label =
 					htonl(0xfffff);
+				user_param->flow_label[1] = user_param->flow_label[1] + 1;
 			}
 			memcpy((void*)&ipv6_spec->mask.dst_ip, ipv6_mask, 16);
 			memcpy((void*)&ipv6_spec->mask.src_ip, ipv6_mask, 16);


### PR DESCRIPTION
For different QP, it may need to set different flow_label. Extend the flow_label option to support list val configuration and keep compatibility.