### PR TITLE
Fix qp_timeout argument in the RDMA CM path

### DIFF
--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -1291,6 +1291,7 @@ int create_comm_struct(struct perftest_comm *comm,
 	comm->rdma_params->output      		= user_param->output;
 	comm->rdma_params->report_per_port 	= user_param->report_per_port;
 	comm->rdma_params->retry_count		= user_param->retry_count;
+	comm->rdma_params->qp_timeout		= user_param->qp_timeout;
 	comm->rdma_params->mr_per_qp		= user_param->mr_per_qp;
 	comm->rdma_params->dlid			= user_param->dlid;
 	comm->rdma_params->cycle_buffer         = user_param->cycle_buffer;

--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -2329,6 +2329,14 @@ int rdma_cm_address_handler(struct pingpong_context *ctx,
 		}
 	}
 
+	rc = rdma_set_option(cma_id, RDMA_OPTION_ID, RDMA_OPTION_ID_ACK_TIMEOUT,
+			     &user_param->qp_timeout, sizeof(uint8_t));
+	if (rc) {
+		error_message = "Failed to set qp_timeout.";
+		rdma_cm_connect_error(ctx);
+		goto error;
+	}
+
 	rc = rdma_resolve_route(cma_id, 2000);
 	if (rc) {
 		error_message = "Failed to resolve RDMA CM route.";
@@ -2461,6 +2469,14 @@ int rdma_cm_connection_request_handler(struct pingpong_context *ctx,
 	if (rc) {
 		error_message = \
 			"Failed request UD connection parameters for RDMA CM.";
+		goto error_2;
+	}
+
+	rc = rdma_set_option(ctx->cm_id, RDMA_OPTION_ID,
+			     RDMA_OPTION_ID_ACK_TIMEOUT,
+			     &user_param->qp_timeout, sizeof(uint8_t));
+	if (rc) {
+		error_message = "Failed to set qp_timeout.";
 		goto error_2;
 	}
 


### PR DESCRIPTION
This PR fixes ccae5242bbdb2c8642fdc66d949b901ee3b81eaf and sets qp_timeout when making the connection actually used for data transfer.