### PR TITLE
Add DDP support for MLNX devices

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,6 +165,14 @@ fi
 
 AC_TRY_LINK([
 #include <infiniband/mlx5dv.h>],
+	[int x = MLX5DV_CONTEXT_MASK_OOO_RECV_WRS;],[HAVE_OOO_RECV_WRS=yes], [HAVE_OOO_RECV_WRS=no])
+AM_CONDITIONAL([HAVE_OOO_RECV_WRS],[test "x$HAVE_OOO_RECV_WRS" = "xyes"])
+if [test $HAVE_OOO_RECV_WRS = yes] && [test $HAVE_MLX5DV = yes]; then
+	AC_DEFINE([HAVE_OOO_RECV_WRS], [1], [Have DDP support])
+fi
+
+AC_TRY_LINK([
+#include <infiniband/mlx5dv.h>],
         [int x = MLX5DV_CRYPTO_STANDARD_AES_XTS;],[HAVE_AES_XTS=yes], [HAVE_AES_XTS=no])
 AM_CONDITIONAL([HAVE_AES_XTS],[test "x$HAVE_AES_XTS" = "xyes"])
 if [test $HAVE_AES_XTS = yes] && [test $HAVE_MLX5DV = yes];  then

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -472,6 +472,11 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 	printf(" No lock in IO, including post send, post recv, post srq recv and poll cq \n");
 	#endif
 
+	#ifdef HAVE_OOO_RECV_WRS
+	printf("      --no_ddp ");
+	printf(" Disable the receiver capability to consume out-of-order WRs. \n");
+	#endif
+
 	if (connection_type != RawEth) {
 		printf("      --ipv6 ");
 		printf(" Use IPv6 GID. Default is IPv4\n");
@@ -892,6 +897,7 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->congest_type	= OFF;
 	user_param->no_lock		= OFF;
 	user_param->use_ddp		= OFF;
+	user_param->no_ddp		= OFF;
 }
 
 static int open_file_write(const char* file_path)
@@ -2367,6 +2373,9 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	#ifdef HAVE_TD_API
 	static int no_lock_flag = 0;
 	#endif
+	#ifdef HAVE_OOO_RECV_WRS
+	static int no_ddp_flag = 0;
+	#endif
 
 	char *server_ip = NULL;
 	char *client_ip = NULL;
@@ -2529,6 +2538,9 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			#endif
 			{.name = "bind_source_ip", .has_arg = 1, .flag = &source_ip_flag, .val = 1},
 			{.name = "write_with_imm", .has_arg = 0, .flag = &use_write_with_imm_flag, .val = 1 },
+			#ifdef HAVE_OOO_RECV_WRS
+			{ .name = "no_ddp",		.has_arg = 0, .flag = &no_ddp_flag, .val = 1},
+			#endif
 			#ifdef HAVE_SRD_WITH_UNSOLICITED_WRITE_RECV
 			{.name = "unsolicited_write", .has_arg = 0, .flag = &unsolicited_write_flag, .val = 1 },
 			#endif
@@ -3212,6 +3224,12 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	#ifdef HAVE_TD_API
 	if (no_lock_flag) {
 		user_param->no_lock = 1;
+	}
+	#endif
+
+	#ifdef HAVE_OOO_RECV_WRS
+	if (no_ddp_flag) {
+		user_param->no_ddp = 1;
 	}
 	#endif
 

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -891,6 +891,7 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->use_unsolicited_write = 0;
 	user_param->congest_type	= OFF;
 	user_param->no_lock		= OFF;
+	user_param->use_ddp		= OFF;
 }
 
 static int open_file_write(const char* file_path)
@@ -3576,7 +3577,7 @@ void ctx_print_test_info(struct perftest_parameters *user_param)
 	#endif //HAVE_TD_API
 	#endif
 
-	printf(" ibv_wr* API     : %s\n", user_param->use_old_post_send ? "OFF" : "ON");
+	printf(" ibv_wr* API     : %s\t\tUsing DDP      : %s\n", user_param->use_old_post_send ? "OFF" : "ON", user_param->use_ddp ? "ON" : "OFF");
 	if (user_param->machine == CLIENT || user_param->duplex) {
 		printf(" TX depth        : %d\n",user_param->tx_depth);
 	}

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -641,6 +641,7 @@ struct perftest_parameters {
 	int				use_write_with_imm;
 	int				use_unsolicited_write;
 	int				use_ddp;
+	int				no_ddp;
 };
 
 struct report_options {

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -640,6 +640,7 @@ struct perftest_parameters {
 	int 			ah_allocated;
 	int				use_write_with_imm;
 	int				use_unsolicited_write;
+	int				use_ddp;
 };
 
 struct report_options {

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -2455,19 +2455,21 @@ struct ibv_qp* ctx_qp_create(struct pingpong_context *ctx,
 		{
 			#ifdef HAVE_MLX5DV
 			#ifdef HAVE_OOO_RECV_WRS
-			ctx_dv.comp_mask = MLX5DV_CONTEXT_MASK_OOO_RECV_WRS;
+			if (!user_param->no_ddp){
+				ctx_dv.comp_mask = MLX5DV_CONTEXT_MASK_OOO_RECV_WRS;
 
-			int ret = mlx5dv_query_device(ctx->context, &ctx_dv);
+				int ret = mlx5dv_query_device(ctx->context, &ctx_dv);
 
-			if (ret) {
-				fprintf(stderr, "Failed to query device capabilities, ret=%d\n", ret);
-				return NULL;
-			}
+				if (ret) {
+					fprintf(stderr, "Failed to query device capabilities, ret=%d\n", ret);
+					return NULL;
+				}
 
-			if (ctx_dv.comp_mask & MLX5DV_CONTEXT_MASK_OOO_RECV_WRS) {
-				user_param->use_ddp = ON;
-				attr_dv.create_flags |= MLX5DV_QP_CREATE_OOO_DP;
-				attr_dv.comp_mask |= MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
+				if (ctx_dv.comp_mask & MLX5DV_CONTEXT_MASK_OOO_RECV_WRS) {
+					user_param->use_ddp = ON;
+					attr_dv.create_flags |= MLX5DV_QP_CREATE_OOO_DP;
+					attr_dv.comp_mask |= MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
+				}
 			}
 			#endif
 			if (user_param->connection_type == DC)

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -2465,7 +2465,9 @@ struct ibv_qp* ctx_qp_create(struct pingpong_context *ctx,
 			}
 
 			if (ctx_dv.comp_mask & MLX5DV_CONTEXT_MASK_OOO_RECV_WRS) {
+				user_param->use_ddp = ON;
 				attr_dv.create_flags |= MLX5DV_QP_CREATE_OOO_DP;
+				attr_dv.comp_mask |= MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
 			}
 			#endif
 			if (user_param->connection_type == DC)


### PR DESCRIPTION
This PR introduces Direct Data Placement (DDP) support in Perftest for MLNX devices.

- Default DDP Enablement: Enables DDP by default when supported by the hardware and environment.
- Reporting: Adds an indication in the report to specify if DDP is used.
- Configurable DDP: Introduces a flag to disable DDP, allowing users to opt out even if supported by the hardware, providing flexibility in scenarios where DDP may not be desired.
- Validation for OOO Receive WQ: Adds a check for max_ooo_recv_wrs_caps to ensure RX depth stays within hardware limitations for OOO receives when DDP is enabled, avoiding potential misconfigurations during QP creation.