### PR TITLE
Use zero size receive buffers for write w/imm

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -3244,6 +3244,10 @@ int ctx_set_recv_wqes(struct pingpong_context *ctx,struct perftest_parameters *u
 	int mtu = MTU_SIZE(user_param->curr_mtu);
 	uint64_t length = user_param->use_srq == ON ? (((SIZE(user_param->connection_type ,user_param->size, 1) + mtu - 1 )/ mtu) * mtu) : SIZE(user_param->connection_type, user_param->size, 1);
 
+	/* Write w/imm completions have zero recieve buffer length */
+	if (user_param->verb == WRITE_IMM)
+		length = 0;
+
 	if((user_param->use_xrc || user_param->connection_type == DC) &&
 				(user_param->duplex || user_param->tst == LAT)) {
 


### PR DESCRIPTION
WRITE w/ immediate RX completions have zero buffer length. Using the test buffer size is not required and can also lead to errors when posting receive buffers larger than the device supports.