### PR TITLE
Add correct list of dependency packages for perftest

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Vcs-Browser: http://git.openfabrics.org/git?p=~shamoya/perftest.git;a=summary
 
 Package: perftest
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libibverbs1 (>= 1.1.6), librdmacm1 (>=1.0.8)
+Depends: ${shlibs:Depends}, ${misc:Depends}, libibverbs1 (>= 1.1.6), librdmacm1 (>=1.0.8), libibumad, rdma-core
 Description: Infiniband verbs performance tests
  This is a collection of tests written using Infiniband verbs intended for
  use as a performance micro-benchmark. The tests can measure the latency

--- a/perftest.spec
+++ b/perftest.spec
@@ -9,6 +9,7 @@ Url:            http://www.openfabrics.org
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  libibverbs-devel librdmacm-devel libibumad-devel
 BuildRequires:  pciutils-devel
+Requires:       libibverbs libibumad librdmacm libpci3 rdma-core
 
 %description
 gen3 uverbs microbenchmarks


### PR DESCRIPTION
While creating .deb and .rpm packages for perftest, some dependencies for proper operation are missing. This patch adds the correct list of minimum required packages that include all the necessary libraries for perftest to function successfully.

For rpm package was added the following list of dependencies`
`libibverbs, libibumad, librdmacm, libpci3, rdma-core`

For deb package was added `libibumad` and` rdma-core`, which were missing.