### PR TITLE
perftest: update payload_file_path & flow_label format man page

### DIFF
--- a/man/perftest.1
+++ b/man/perftest.1
@@ -298,7 +298,7 @@ many different options and modes.
  bw (bandwidth / message_rate), latency (latency).
 .TP
 .B --payload_file_path=<payload_txt_file_path>
- Set the payload by passing a txt file containing a pattern in the next form(little endian): '0xaaaaaaaa, 0xbbbbbbbb, ...
+ Set the payload by passing a txt file containing a pattern in the next form(little endian): '0xaaaaaaaa,0xbbbbbbbb,...
  Not relevant for RawEth and Write latency.
 .TP
 .B --use_old_post_send
@@ -481,7 +481,7 @@ many different options and modes.
  Not relevant for raw_ethernet_fs_rate.
  System support required.
 .TP
-.B --flow_label=<fl0, fl1,...>
+.B --flow_label=<fl0,fl1,...>
  IPv6 flow label.
  Not relevant for raw_ethernet_fs_rate.
 .TP

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -560,7 +560,7 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 
 	if (connection_type != RawEth && !((verb == WRITE || verb == WRITE_IMM) && tst == LAT)) {
 		printf("      --payload_file_path=<payload_txt_file_path>");
-		printf(" Set the payload by passing a txt file containing a pattern in the next form(little endian): '0xaaaaaaaa, 0xbbbbbbbb, ...' .\n");
+		printf(" Set the payload by passing a txt file containing a pattern in the next form(little endian): '0xaaaaaaaa,0xbbbbbbbb,...' .\n");
 	}
 
 	printf(" Latency measurement is Average calculation \n");


### PR DESCRIPTION
There's no space for
1) the data pattern in payload_file_path
https://github.com/linux-rdma/perftest/blob/24.10.0-0.66/src/perftest_resources.c#L1789
https://github.com/linux-rdma/perftest/blob/24.10.0-0.66/src/perftest_resources.c#L1817
2) flow_label option parameters
https://github.com/linux-rdma/perftest/blob/master/src/perftest_parameters.c#L137