### PR TITLE
Add support for DMA-buffers in Cambricon devices

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -379,6 +379,9 @@ AS_IF([test "x$enable_mlu" = xyes], [
                         [AC_MSG_ERROR([could not find cn_api.h in include path])])
        AC_SEARCH_LIBS([cnMalloc], [cndrv], [],
                       [AC_MSG_ERROR([could not find library, cndrv])])
+       AC_SEARCH_LIBS([cnMemGetHandleForAddressRange], [cndrv],
+					  [AC_DEFINE([HAVE_MLU_DMABUF], [1], [Enable MLU DMA buffers])],
+		      [])
        ])
 
 AM_CONDITIONAL([MLU], [test x$enable_mlu = xyes])

--- a/man/perftest.1
+++ b/man/perftest.1
@@ -375,6 +375,14 @@ many different options and modes.
  Not relevant for raw_ethernet_fs_rate.
  System support required.
 .TP
+.B --use_mlu=<mlu device id>
+ Use MLU specific device for HW accelerator direct RDMA testing.
+ System support required.
+.TP
+.B --use_mlu_dmabuf
+ Use MLU DMA-BUF for HW accelerator direct RDMA testing.
+ System support required.
+.TP
 .B --use_hugepages
  Use Hugepages instead of contig, memalign allocations.
  Not relevant for raw_ethernet_fs_rate.

--- a/src/mlu_memory.c
+++ b/src/mlu_memory.c
@@ -43,7 +43,7 @@ struct mlu_memory_ctx {
 	int device_id;
 	CNdev cnDevice;
 	CNcontext cnContext;
-
+	bool use_dmabuf;
 };
 
 
@@ -129,6 +129,18 @@ int mlu_memory_init(struct memory_ctx *ctx) {
 		return FAILURE;
 	}
 
+#ifdef HAVE_MLU_DMABUF
+	if (mlu_ctx->use_dmabuf) {
+		int is_supported = 0;
+
+		ERROR_CHECK(cnDeviceGetAttribute(&is_supported, CN_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED, mlu_ctx->cnDevice));
+		if (!is_supported) {
+			fprintf(stderr, "DMA-BUF is not supported on this MLU\n");
+			return FAILURE;
+		}
+	}
+#endif
+
 	return SUCCESS;
 }
 
@@ -145,6 +157,7 @@ int mlu_memory_allocate_buffer(struct memory_ctx *ctx, int alignment, uint64_t s
 	CNresult error;
 	size_t buf_size = (size + ACCEL_PAGE_SIZE - 1) & ~(ACCEL_PAGE_SIZE - 1);
 
+	struct mlu_memory_ctx *mlu_ctx = container_of(ctx, struct mlu_memory_ctx, base);
 	CNaddr mlu_addr;
 	printf("cnMalloc() of a %lu bytes MLU buffer\n", size);
 
@@ -157,6 +170,33 @@ int mlu_memory_allocate_buffer(struct memory_ctx *ctx, int alignment, uint64_t s
 	printf("allocated %lu bytes of MLU buffer at %ld\n", (unsigned long)buf_size, mlu_addr);
 	*addr = (void *)mlu_addr;
 	*can_init = false;
+
+#ifdef HAVE_MLU_DMABUF
+	{
+		if (mlu_ctx->use_dmabuf) {
+			CNaddr aligned_ptr;
+			const size_t host_page_size = sysconf(_SC_PAGESIZE);
+			uint64_t offset;
+			size_t aligned_size;
+
+			// Round down to host page size
+			aligned_ptr = mlu_addr & ~(host_page_size - 1);
+			offset = mlu_addr - aligned_ptr;
+			aligned_size = (size + offset + host_page_size - 1) & ~(host_page_size - 1);
+
+			printf("using DMA-BUF for MLU buffer address at %#llx aligned at %#llx with aligned size %zu\n", mlu_addr, aligned_ptr, aligned_size);
+			*dmabuf_fd = 0;
+			error = cnMemGetHandleForAddressRange((void *)dmabuf_fd, aligned_ptr, aligned_size, CN_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+			if (error != CN_SUCCESS) {
+				printf("cnMemGetHandleForAddressRange error=%d\n", error);
+				return FAILURE;
+			}
+
+			*dmabuf_offset = offset;
+		}
+	}
+#endif
+
 	return SUCCESS;
 }
 
@@ -182,6 +222,14 @@ bool mlu_memory_supported() {
 	return true;
 }
 
+bool mlu_memory_dmabuf_supported() {
+#ifdef HAVE_MLU_DMABUF
+	return true;
+#else
+	return false;
+#endif
+}
+
 struct memory_ctx *mlu_memory_create(struct perftest_parameters *params) {
 	struct mlu_memory_ctx *ctx;
 
@@ -194,6 +242,7 @@ struct memory_ctx *mlu_memory_create(struct perftest_parameters *params) {
 	ctx->base.copy_buffer_to_host = mlu_memory_copy_host_buffer;
 	ctx->base.copy_buffer_to_buffer = mlu_memory_copy_buffer_to_buffer;
 	ctx->device_id = params->mlu_device_id;
+	ctx->use_dmabuf = params->use_mlu_dmabuf;
 
 	return &ctx->base;
 }

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -650,6 +650,11 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		if (mlu_memory_supported()) {
 			printf("      --use_mlu=<mlu device id>");
 			printf(" Use selected MLU device for MLUDirect RDMA testing\n");
+
+			if (mlu_memory_dmabuf_supported()) {
+				printf("      --use_mlu_dmabuf");
+				printf(" Use DMA-BUF for HW accelerator direct RDMA testing\n");
+			}
 		}
 
 		printf("      --use_hugepages ");
@@ -879,6 +884,7 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->rocm_device_id	= 0;
 	user_param->neuron_core_id	= 0;
 	user_param->mlu_device_id	= 0;
+	user_param->use_mlu_dmabuf	= 0;
 	user_param->mmap_file		= NULL;
 	user_param->mmap_offset		= 0;
 	user_param->iters_per_port[0]	= 0;
@@ -2374,6 +2380,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	static int use_neuron_dmabuf_flag = 0;
 	static int use_hl_flag = 0;
 	static int use_mlu_flag = 0;
+	static int use_mlu_dmabuf_flag = 0;
 	static int disable_pcir_flag = 0;
 	static int mmap_file_flag = 0;
 	static int mmap_offset_flag = 0;
@@ -2542,6 +2549,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{ .name = "use_cuda_bus_id",	.has_arg = 1, .flag = &use_cuda_bus_id_flag, .val = 1},
 			{ .name = "use_cuda_dmabuf",	.has_arg = 0, .flag = &use_cuda_dmabuf_flag, .val = 1},
 			{ .name = "use_data_direct",	.has_arg = 0, .flag = &use_data_direct_flag, .val = 1},
+			{ .name = "use_mlu_dmabuf",	.has_arg = 0, .flag = &use_mlu_dmabuf_flag, .val = 1},
 			{ .name = "use_rocm",		.has_arg = 1, .flag = &use_rocm_flag, .val = 1},
 			{ .name = "use_neuron",		.has_arg = 1, .flag = &use_neuron_flag, .val = 1},
 			{ .name = "use_neuron_dmabuf",	.has_arg = 0, .flag = &use_neuron_dmabuf_flag, .val = 1},
@@ -2985,7 +2993,8 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				    (use_neuron_flag && !neuron_memory_supported()) ||
 				    (use_neuron_dmabuf_flag && !neuron_memory_dmabuf_supported()) ||
 				    (use_hl_flag && !hl_memory_supported()) ||
-				    (use_mlu_flag && !mlu_memory_supported())) {
+				    (use_mlu_flag && !mlu_memory_supported()) ||
+				    (use_mlu_dmabuf_flag && !mlu_memory_dmabuf_supported())) {
 					printf(" Unsupported memory type\n");
 					return FAILURE;
 				}
@@ -3062,6 +3071,15 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 					user_param->memory_type = MEMORY_MLU;
 					user_param->memory_create = mlu_memory_create;
 					use_mlu_flag = 0;
+				}
+				if (use_mlu_dmabuf_flag) {
+					user_param->use_mlu_dmabuf = 1;
+					if (user_param->memory_type != MEMORY_MLU) {
+						fprintf(stderr, "MLU DMA-BUF cannot be used without MLU device\n");
+						free(duplicates_checker);
+						return FAILURE;
+					}
+					use_mlu_dmabuf_flag = 0;
 				}
 				if (flow_label_flag) {
 					if (parse_flow_label_from_str(user_param, optarg)) {

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -579,6 +579,7 @@ struct perftest_parameters {
 	int				use_neuron_dmabuf;
 	char				*hl_device_bus_id;
 	int				mlu_device_id;
+	int				use_mlu_dmabuf;
 	char				*mmap_file;
 	unsigned long			mmap_offset;
 	/* New test params format pilot. will be used in all flags soon,. */


### PR DESCRIPTION
To build with MLU DMA-BUF support, use:
./configure --enable-mlu  --with-mlu=</usr/local/neuware>

To run with MLU DMA-BUF enabled, use:
ib_write_bw  --use_mlu_dmabuf --use_mlu=<device id>
