### PR TITLE
Detect when a device is rxe (soft RoCE) 

### DIFF
--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,0 +1,10 @@
+Tests: rxe_loopback
+Depends:
+ @,
+ rdma-core,
+ iproute2,
+ psmisc,
+Restrictions:
+ superficial,
+ needs-root,
+ isolation-machine,

--- a/debian/tests/rxe_loopback
+++ b/debian/tests/rxe_loopback
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+set -e
+
+link_name="rxe_test"
+port_index=1 # Always?
+dev_name="$link_name/$port_index"
+
+get_eth_dev() {
+	ip -o link | awk '/link\/ether/ {print $2}' | tr -d : | head -n1
+}
+
+do_init() {
+	base_link=`get_eth_dev`
+	if rdma link show "$dev_name" >/dev/null 2>&1; then
+		echo "$0: Error: rdma link $link_name already exists. Run $0 shutdown"
+	else
+		rdma link add "$link_name" type rxe netdev "$base_link"
+	fi
+}
+
+run_loopback() {
+	echo "==== Running loopback for $*: ===="
+	run_loopback_server "$@" &
+	sleep 1
+	run_loopback_client "$@"
+	echo "==== Done    loopback for $*: ===="
+
+}
+
+run_loopback_server() {
+	command_name="$1"
+
+	"$@" ||  killall "$command_name" || :
+}
+
+run_loopback_client() {
+	"$@" localhost
+}
+
+
+do_check() {
+	run_loopback ib_write_bw -s 10
+	run_loopback ib_read_bw
+	run_loopback ib_send_bw
+	run_loopback ib_atomic_bw
+	run_loopback ib_write_lat
+	run_loopback ib_atomic_lat
+	run_loopback ib_write_lat
+	# Can't test:
+	# run_loopback raw_ethernet_burst_lat
+	# run_loopback raw_ethernet_bw
+	# run_loopback raw_ethernet_fs_rate
+	# run_loopback raw_ethernet_lat
+}
+
+do_shutdown() {
+	if rdma link show "$dev_name" >/dev/null 2>&1; then
+		rdma link delete "$link_name"
+	fi
+}
+
+do_all() {
+	do_init
+	do_check
+	do_shutdown
+}
+
+do_help() {
+	echo "$0 <all | init | check | shutdown>" 
+}
+
+case "$1" in
+init | check | shutdown | help | all)
+	cmd="$1"
+	shift
+	do_$cmd "$@"
+	;;
+'') do_all;;
+*) do_help; exit 1
+esac

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1952,6 +1952,14 @@ const int str_link_layer(const char *str)
 		return LINK_FAILURE;
 }
 
+bool is_rxe_heuristic(const struct ibv_context *context)
+{
+	if (context->device == NULL) {
+		return false;
+	}
+	return ! strncmp("rxe", context->device->name, 3);
+}
+
 /******************************************************************************
  *
  ******************************************************************************/
@@ -2075,6 +2083,11 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 			case 41512 : dev_fname = HNS; break;
 			case 41519 : dev_fname = HNS; break;
 			default	   : dev_fname = UNKNOWN;
+		}
+	}
+	if (dev_fname == UNKNOWN) {
+		if (is_rxe_heuristic(context)) {
+			dev_fname = RXE;
 		}
 	}
 

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -387,6 +387,7 @@ enum ctx_device {
 	CONNECTX8		= 31,
   	INTEL_GEN2		= 32,
 	CONNECTX9               = 33,
+	RXE			= 33,
 };
 
 /* Units for rate limiter */


### PR DESCRIPTION
Added a heuristic to detect when a device is rxe (rdma-core soft-RoCE driver).

First patch is the required change. Second patch is mostly added  as a motivator and I'm not sure I want to keep it here.

Motivation: I wanted to add some self checks to the package I include in Debian. Debian uses a packages testing framework called autopkgtest. The only device I can get to work on a generic machine is rxe. I created a test for it.

Tests ran generally OK (with no errors. I'm not completely sure if I could have better monitoring of results. I still mark them as "superficial"). But some spit an line to standard error about "Device not recognized to implement inline feature. Disabling it", and autopkgtest's default logic is that output to stderr means an error. So I wanted to avoid that to catch real errors.

** Running the test: **
The second commit has the script. By default it runs everything (including "setup" and "shutdown" operations that create and destroy a rxe interface, accordingly. I have not tested it on a machine with a real interface.

If you actually want to test autopkgtest:

    sudo apt install autopkgtest   # maybe also need to install mmdebootstrap
    sudo autopkgtest-build-qemu unstable /var/cache/autopkgtest/vm/unstable.img
    # In the top-level directory of this repository:
    autopkgtest . -- qemu /var/cache/autopkgtest/vm/unstable.img