### PR TITLE
Add support for DMA-buffers in Cambricon devices

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -447,6 +447,9 @@ AS_IF([test "x$enable_mlu" = xyes], [
                         [AC_MSG_ERROR([could not find cn_api.h in include path])])
        AC_SEARCH_LIBS([cnMalloc], [cndrv], [],
                       [AC_MSG_ERROR([could not find library, cndrv])])
+       AC_SEARCH_LIBS([cnMemGetHandleForAddressRange], [cndrv],
+					  [AC_DEFINE([HAVE_MLU_DMABUF], [1], [Enable MLU DMA buffers])],
+		      [])
        ])
 
 AM_CONDITIONAL([MLU], [test x$enable_mlu = xyes])

--- a/man/perftest.1
+++ b/man/perftest.1
@@ -389,6 +389,14 @@ many different options and modes.
  Not relevant for raw_ethernet_fs_rate.
  System support required.
 .TP
+.B --use_mlu=<mlu device id>
+ Use MLU specific device for HW accelerator direct RDMA testing.
+ System support required.
+.TP
+.B --use_mlu_dmabuf
+ Use MLU DMA-BUF for HW accelerator direct RDMA testing.
+ System support required.
+.TP
 .B --use_opencl=<opencl device id>
  Use OpenCl specific device for GPUDirect RDMA testing
  Not relevant for raw_ethernet_fs_rate.

--- a/src/mlu_memory.h
+++ b/src/mlu_memory.h
@@ -16,12 +16,18 @@ struct perftest_parameters;
 
 bool mlu_memory_supported();
 
+bool mlu_memory_dmabuf_supported();
+
 struct memory_ctx *mlu_memory_create(struct perftest_parameters *params);
 
 
 #ifndef HAVE_MLU
 
 inline bool mlu_memory_supported() {
+	return false;
+}
+
+inline bool mlu_memory_dmabuf_supported() {
 	return false;
 }
 

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1903,6 +1903,18 @@ static void force_dependecies(struct perftest_parameters *user_param)
 		exit(1);
 	}
 
+	if (user_param->memory_type == MEMORY_MLU && user_param->tst == LAT && (user_param->verb == WRITE || user_param->verb == WRITE_IMM)) {
+		printf(RESULT_LINE);
+		fprintf(stderr,"Perftest supports MLU latency tests with read/send verbs only\n");
+		exit(1);
+	}
+
+	if (user_param->memory_type == MEMORY_MLU && (int)user_param->size <= user_param->inline_size) {
+		printf(RESULT_LINE);
+		fprintf(stderr,"Perftest doesn't support MLU tests with inline messages\n");
+		exit(1);
+	}
+
 	if (user_param->use_data_direct) {
 		user_param->use_cuda_pcie_mapping = 1;
 	}
@@ -2336,6 +2348,12 @@ static void ctx_set_max_inline(struct ibv_context *context,struct perftest_param
 		if (user_param->memory_type == MEMORY_CUDA){
 			user_param->inline_size = 0;
 			printf("Perftest doesn't supports CUDA tests with inline messages: inline size set to 0\n");
+			return;
+		}
+
+		if (user_param->memory_type == MEMORY_MLU){
+			user_param->inline_size = 0;
+			printf("Perftest doesn't supports MLU tests with inline messages: inline size set to 0\n");
 			return;
 		}
 

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -668,6 +668,11 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		if (mlu_memory_supported()) {
 			printf("      --use_mlu=<mlu device id>");
 			printf(" Use selected MLU device for MLUDirect RDMA testing\n");
+
+			if (mlu_memory_dmabuf_supported()) {
+				printf("      --use_mlu_dmabuf");
+				printf(" Use DMA-BUF for HW accelerator direct RDMA testing\n");
+			}
 		}
 
 		if (opencl_memory_supported()) {
@@ -913,6 +918,7 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->rocm_device_id	= 0;
 	user_param->neuron_core_id	= 0;
 	user_param->mlu_device_id	= 0;
+	user_param->use_mlu_dmabuf	= 0;
 	user_param->opencl_platform_id	= 0;
 	user_param->opencl_device_id	= 0;
 	user_param->gpu_touch		= GPU_NO_TOUCH;
@@ -2434,6 +2440,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	static int use_neuron_dmabuf_flag = 0;
 	static int use_hl_flag = 0;
 	static int use_mlu_flag = 0;
+	static int use_mlu_dmabuf_flag = 0;
 	static int use_opencl_flag = 0;
 	static int opencl_platform_id_flag = 0;
 	static int gpu_touch_flag = 0;
@@ -2614,6 +2621,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{ .name = "use_neuron_dmabuf",	.has_arg = 0, .flag = &use_neuron_dmabuf_flag, .val = 1},
 			{ .name = "use_hl",		.has_arg = 1, .flag = &use_hl_flag, .val = 1},
 			{ .name = "use_mlu",		.has_arg = 1, .flag = &use_mlu_flag, .val = 1},
+			{ .name = "use_mlu_dmabuf",	.has_arg = 0, .flag = &use_mlu_dmabuf_flag, .val = 1},
 			{ .name = "use_opencl",         .has_arg = 1, .flag = &use_opencl_flag, .val = 1},
 			{ .name = "opencl_platform_id", .has_arg = 1, .flag = &opencl_platform_id_flag, .val = 1},
 			{ .name = "gpu_touch",		.has_arg = 1, .flag = &gpu_touch_flag, .val = 1},
@@ -3061,6 +3069,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				    (use_neuron_dmabuf_flag && !neuron_memory_dmabuf_supported()) ||
 				    (use_hl_flag && !hl_memory_supported()) ||
 				    (use_mlu_flag && !mlu_memory_supported()) ||
+				    (use_mlu_dmabuf_flag && !mlu_memory_dmabuf_supported()) ||
 				    (use_opencl_flag && !opencl_memory_supported())) {
 					printf(" Unsupported memory type\n");
 					return FAILURE;
@@ -3174,6 +3183,15 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 					user_param->memory_type = MEMORY_MLU;
 					user_param->memory_create = mlu_memory_create;
 					use_mlu_flag = 0;
+				}
+				if (use_mlu_dmabuf_flag) {
+					user_param->use_mlu_dmabuf = 1;
+					if (user_param->memory_type != MEMORY_MLU) {
+						fprintf(stderr, "MLU DMA-BUF cannot be used without MLU device\n");
+						free(duplicates_checker);
+						return FAILURE;
+					}
+					use_mlu_dmabuf_flag = 0;
 				}
 
 				if (use_opencl_flag) {

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -599,6 +599,7 @@ struct perftest_parameters {
 	int				use_neuron_dmabuf;
 	char				*hl_device_bus_id;
 	int				mlu_device_id;
+	int				use_mlu_dmabuf;
 	int                             opencl_platform_id;
 	int                             opencl_device_id;
 	int                             gpu_touch;


### PR DESCRIPTION
To build with MLU DMA-BUF support, use:
./configure --enable-mlu  --with-mlu=</usr/local/neuware>

To run with MLU DMA-BUF enabled, use:
ib_write_bw  --use_mlu=device id  --use_mlu_dmabuf 