### PR TITLE
report both local and remote bandwidth in JSON output

### DIFF
--- a/src/atomic_bw.c
+++ b/src/atomic_bw.c
@@ -318,11 +318,14 @@ int main(int argc, char *argv[])
 
 		print_report_bw(&user_param, &my_bw_rep);
 
+		// print either just the local, or the aggregate of local and remote
 		if (user_param.duplex) {
 			xchg_bw_reports(&user_comm, &my_bw_rep, &rem_bw_rep, atof(user_param.rem_version));
 			print_full_bw_report(&user_param, &my_bw_rep, &rem_bw_rep);
 		}
 
+		// print local and remote separately, if separate reporting was requested
+		// and a duplex test was run
 		if (user_param.report_both && user_param.duplex) {
 			printf(RESULT_LINE);
 			printf("\n Local results:\n");
@@ -337,6 +340,11 @@ int main(int argc, char *argv[])
 			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 			print_full_bw_report(&user_param, &rem_bw_rep, NULL);
+		}
+
+		// print JSON, if requested
+		if (user_param.out_json) {
+			print_full_bw_report_to_file(&user_param, &my_bw_rep, &rem_bw_rep);
 		}
 	} else if (user_param.test_method == RUN_INFINITELY) {
 

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -4042,25 +4042,75 @@ static void write_test_info_to_file(int out_json_fds, struct perftest_parameters
 	dprintf(out_json_fds, "\n},\n");
 }
 
-static void write_bw_report_to_file(int out_json_fd, struct perftest_parameters *user_param, int inc_accuracy,
-		double bw_avg, double msgRate_avg, unsigned long size, int sl, uint64_t iters, double bw_peak) {
+static struct bw_report_data sum_bw_reports(struct bw_report_data *my_bw_rep, struct bw_report_data *rem_bw_rep) {
+	struct bw_report_data merged_bw_rep = *my_bw_rep;
 
-	dprintf(out_json_fd, "\"results\": {\n");
+	if (rem_bw_rep != NULL) {
+		merged_bw_rep.bw_peak        += rem_bw_rep->bw_peak;
+		merged_bw_rep.bw_avg         += rem_bw_rep->bw_avg;
+		merged_bw_rep.bw_avg_p1      += rem_bw_rep->bw_avg_p1;
+		merged_bw_rep.bw_avg_p2      += rem_bw_rep->bw_avg_p2;
+		merged_bw_rep.msgRate_avg    += rem_bw_rep->msgRate_avg;
+		merged_bw_rep.msgRate_avg_p1 += rem_bw_rep->msgRate_avg_p1;
+		merged_bw_rep.msgRate_avg_p2 += rem_bw_rep->msgRate_avg_p2;
+	}
+
+	return merged_bw_rep;
+}
+
+static void write_bw_report_data_to_file(int out_json_fd, struct perftest_parameters *user_param, int inc_accuracy,
+	struct bw_report_data *bw_rep) {
 
 	if (user_param->output == OUTPUT_BW)
-		dprintf(out_json_fd, "\"bw_avg\": %lf,\n", bw_avg);
+		dprintf(out_json_fd, "\"bw_avg\": %lf,\n", bw_rep->bw_avg);
 	else if (user_param->output == OUTPUT_MR)
-		dprintf(out_json_fd, "\"msgRate_avg\": %lf,\n", msgRate_avg);
+		dprintf(out_json_fd, "\"msgRate_avg\": %lf,\n", bw_rep->msgRate_avg);
 	else if (user_param->raw_qos)
-		dprintf(out_json_fd, REPORT_FMT_QOS_JSON, size, sl, iters, bw_peak, bw_avg, msgRate_avg);
+		dprintf(out_json_fd, REPORT_FMT_QOS_JSON,
+			bw_rep->size, bw_rep->sl, bw_rep->iters, bw_rep->bw_peak, bw_rep->bw_avg, bw_rep->msgRate_avg);
 	else
 		dprintf(out_json_fd, inc_accuracy ? REPORT_FMT_EXT_JSON : REPORT_FMT_JSON,
-								   size, iters, bw_peak, bw_avg, msgRate_avg);
+			bw_rep->size, bw_rep->iters, bw_rep->bw_peak, bw_rep->bw_avg, bw_rep->msgRate_avg);
 
 	dprintf(out_json_fd, user_param->cpu_util_data.enable ?
 							REPORT_EXT_CPU_UTIL_JSON : REPORT_EXT_JSON, calc_cpu_util(user_param));
+}
 
-	dprintf(out_json_fd, "}\n");
+static void write_bw_report_to_file(int out_json_fd, struct perftest_parameters *user_param,
+	struct bw_report_data *my_bw_rep, struct bw_report_data *rem_bw_rep)
+{
+	struct bw_report_data sum_bw_report = sum_bw_reports(my_bw_rep, rem_bw_rep);
+	int inc_accuracy = ((sum_bw_report.bw_avg < 0.1) && (user_param->report_fmt == GBS));
+
+	dprintf(out_json_fd, "\"results\": {\n");
+	write_bw_report_data_to_file(out_json_fd, user_param, inc_accuracy, &sum_bw_report);
+
+	if (user_param->report_both && rem_bw_rep != NULL) {
+		dprintf(out_json_fd, "},\n");
+	} else {
+		dprintf(out_json_fd, "}\n");
+	}
+
+	if (user_param->report_both && rem_bw_rep != NULL) {
+		dprintf(out_json_fd, "\"results_local\": {\n");
+		write_bw_report_data_to_file(out_json_fd, user_param, inc_accuracy, my_bw_rep);
+		dprintf(out_json_fd, "},\n");
+
+		dprintf(out_json_fd, "\"results_remote\": {\n");
+		write_bw_report_data_to_file(out_json_fd, user_param, inc_accuracy, rem_bw_rep);
+		dprintf(out_json_fd, "}\n");
+	}
+}
+
+void print_full_bw_report_to_file(struct perftest_parameters *user_param, struct bw_report_data *my_bw_rep, struct bw_report_data *rem_bw_rep) {
+	int out_json_fd = open_file_write(user_param->out_json_file_name);
+	if(out_json_fd >= 0){
+		dprintf(out_json_fd,"{\n");
+		write_test_info_to_file(out_json_fd, user_param);
+		write_bw_report_to_file(out_json_fd, user_param, my_bw_rep, rem_bw_rep);
+		dprintf(out_json_fd,"}\n");
+		close(out_json_fd);
+	}
 }
 
 /******************************************************************************
@@ -4069,61 +4119,32 @@ static void write_bw_report_to_file(int out_json_fd, struct perftest_parameters 
 
 void print_full_bw_report (struct perftest_parameters *user_param, struct bw_report_data *my_bw_rep, struct bw_report_data *rem_bw_rep)
 {
-
-	double bw_peak     = my_bw_rep->bw_peak;
-	double bw_avg      = my_bw_rep->bw_avg;
-	double bw_avg_p1      = my_bw_rep->bw_avg_p1;
-	double bw_avg_p2      = my_bw_rep->bw_avg_p2;
-	double msgRate_avg = my_bw_rep->msgRate_avg;
-	double msgRate_avg_p1 = my_bw_rep->msgRate_avg_p1;
-	double msgRate_avg_p2 = my_bw_rep->msgRate_avg_p2;
-	int inc_accuracy = ((bw_avg < 0.1) && (user_param->report_fmt == GBS));
-
-	if (rem_bw_rep != NULL) {
-		bw_peak     += rem_bw_rep->bw_peak;
-		bw_avg      += rem_bw_rep->bw_avg;
-		bw_avg_p1      += rem_bw_rep->bw_avg_p1;
-		bw_avg_p2      += rem_bw_rep->bw_avg_p2;
-		msgRate_avg += rem_bw_rep->msgRate_avg;
-		msgRate_avg_p1 += rem_bw_rep->msgRate_avg_p1;
-		msgRate_avg_p2 += rem_bw_rep->msgRate_avg_p2;
-	}
+	struct bw_report_data sum_bw_report = sum_bw_reports(my_bw_rep, rem_bw_rep);
+	int inc_accuracy = ((sum_bw_report.bw_avg < 0.1) && (user_param->report_fmt == GBS));
 
 	if ( (user_param->duplex && rem_bw_rep != NULL) ||  (!user_param->duplex && rem_bw_rep == NULL) || (user_param->duplex && user_param->verb == SEND)) {
 		/* Verify Limits */
-		if ( ((user_param->is_limit_bw == ON )&& (user_param->limit_bw > bw_avg)) )
+		if ( ((user_param->is_limit_bw == ON )&& (user_param->limit_bw > sum_bw_report.bw_avg)) )
 			user_param->is_bw_limit_passed |= 0;
 		else
 			user_param->is_bw_limit_passed |= 1;
 
-		if ( (user_param->is_limit_msgrate) && (user_param->limit_msgrate > msgRate_avg) )
+		if ( (user_param->is_limit_msgrate) && (user_param->limit_msgrate > sum_bw_report.msgRate_avg) )
 			user_param->is_msgrate_limit_passed |= 0;
 		else
 			user_param->is_msgrate_limit_passed |= 1;
 	}
 
-	if(user_param->out_json) {
-		int out_json_fd = open_file_write(user_param->out_json_file_name);
-		if(out_json_fd >= 0){
-			dprintf(out_json_fd,"{\n");
-			write_test_info_to_file(out_json_fd, user_param);
-			write_bw_report_to_file(out_json_fd, user_param, inc_accuracy,
-					bw_avg, msgRate_avg, my_bw_rep->size, my_bw_rep->sl, my_bw_rep->iters, bw_peak);
-			dprintf(out_json_fd,"}\n");
-			close(out_json_fd);
-		}
-	}
-
 	if (user_param->output == OUTPUT_BW)
-		printf("%lf\n",bw_avg);
+		printf("%lf\n",sum_bw_report.bw_avg);
 	else if (user_param->output == OUTPUT_MR)
-		printf("%lf\n",msgRate_avg);
+		printf("%lf\n",sum_bw_report.msgRate_avg);
 	else if (user_param->raw_qos)
-		printf( REPORT_FMT_QOS, my_bw_rep->size, my_bw_rep->sl, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg);
+		printf( REPORT_FMT_QOS, sum_bw_report.size, sum_bw_report.sl, sum_bw_report.iters, sum_bw_report.bw_peak, sum_bw_report.bw_avg, sum_bw_report.msgRate_avg);
 	else if (user_param->report_per_port)
-		printf(REPORT_FMT_PER_PORT, my_bw_rep->size, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg, bw_avg_p1, msgRate_avg_p1, bw_avg_p2, msgRate_avg_p2);
+		printf(REPORT_FMT_PER_PORT, sum_bw_report.size, sum_bw_report.iters, sum_bw_report.bw_peak, sum_bw_report.bw_avg, sum_bw_report.msgRate_avg, sum_bw_report.bw_avg_p1, sum_bw_report.msgRate_avg_p1, sum_bw_report.bw_avg_p2, sum_bw_report.msgRate_avg_p2);
 	else
-		printf( inc_accuracy ? REPORT_FMT_EXT : REPORT_FMT, my_bw_rep->size, my_bw_rep->iters, bw_peak, bw_avg, msgRate_avg);
+		printf( inc_accuracy ? REPORT_FMT_EXT : REPORT_FMT, sum_bw_report.size, sum_bw_report.iters, sum_bw_report.bw_peak, sum_bw_report.bw_avg, sum_bw_report.msgRate_avg);
 	if (user_param->output == FULL_VERBOSITY) {
 		fflush(stdout);
 		fprintf(stdout, user_param->cpu_util_data.enable ? REPORT_EXT_CPU_UTIL : REPORT_EXT , calc_cpu_util(user_param));

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -791,6 +791,8 @@ void ctx_print_test_info(struct perftest_parameters *user_param);
  */
 void print_report_bw (struct perftest_parameters *user_param, struct bw_report_data *my_bw_rep);
 
+void print_full_bw_report_to_file (struct perftest_parameters *user_param, struct bw_report_data *my_bw_rep, struct bw_report_data *rem_bw_rep);
+
 /* print_full_bw_report
  *
  * Description : Print the peak and average throughput of the BW test.

--- a/src/read_bw.c
+++ b/src/read_bw.c
@@ -364,11 +364,14 @@ int main(int argc, char *argv[])
 
 		print_report_bw(&user_param,&my_bw_rep);
 
+		// print either just the local, or the aggregate of local and remote
 		if (user_param.duplex) {
 			xchg_bw_reports(&user_comm, &my_bw_rep,&rem_bw_rep,atof(user_param.rem_version));
 			print_full_bw_report(&user_param, &my_bw_rep, &rem_bw_rep);
 		}
 
+		// print local and remote separately, if separate reporting was requested
+		// and a duplex test was run
 		if (user_param.report_both && user_param.duplex) {
 			printf(RESULT_LINE);
 			printf("\n Local results: \n");
@@ -383,6 +386,11 @@ int main(int argc, char *argv[])
 			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 			print_full_bw_report(&user_param, &rem_bw_rep, NULL);
+		}
+
+		// print JSON, if requested
+		if (user_param.out_json) {
+			print_full_bw_report_to_file(&user_param, &my_bw_rep, &rem_bw_rep);
 		}
 	} else if (user_param.test_method == RUN_INFINITELY) {
 

--- a/src/send_bw.c
+++ b/src/send_bw.c
@@ -515,11 +515,14 @@ int main(int argc, char *argv[])
 
 		print_report_bw(&user_param,&my_bw_rep);
 
+		// print either just the local, or the aggregate of local and remote
 		if (user_param.duplex && user_param.test_type != DURATION) {
 			xchg_bw_reports(&user_comm, &my_bw_rep,&rem_bw_rep,atof(user_param.rem_version));
 			print_full_bw_report(&user_param, &my_bw_rep, &rem_bw_rep);
 		}
 
+		// print local and remote separately, if separate reporting was requested
+		// and a duplex test was run
 		if (user_param.report_both && user_param.duplex) {
 			printf(RESULT_LINE);
 			printf("\n Local results: \n");
@@ -534,6 +537,11 @@ int main(int argc, char *argv[])
 			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 			print_full_bw_report(&user_param, &rem_bw_rep, NULL);
+		}
+
+		// print JSON, if requested
+		if (user_param.out_json) {
+			print_full_bw_report_to_file(&user_param, &my_bw_rep, &rem_bw_rep);
 		}
 	} else if (user_param.test_method == RUN_INFINITELY) {
 

--- a/src/write_bw.c
+++ b/src/write_bw.c
@@ -309,7 +309,7 @@ int main(int argc, char *argv[])
 				ctx_set_send_wqes(&ctx,&user_param,rem_dest);
 
 			if (user_param.verb == WRITE_IMM && !user_param.use_unsolicited_write &&
-			    (user_param.machine == SERVER || user_param.duplex)) {
+				(user_param.machine == SERVER || user_param.duplex)) {
 				if (ctx_set_recv_wqes(&ctx,&user_param)) {
 					fprintf(stderr," Failed to post receive recv_wqes\n");
 					goto free_mem;
@@ -424,11 +424,14 @@ int main(int argc, char *argv[])
 
 		print_report_bw(&user_param,&my_bw_rep);
 
+		// print either just the local, or the aggregate of local and remote
 		if (user_param.duplex && (user_param.verb != WRITE_IMM || user_param.test_type != DURATION)) {
 			xchg_bw_reports(&user_comm, &my_bw_rep,&rem_bw_rep,atof(user_param.rem_version));
 			print_full_bw_report(&user_param, &my_bw_rep, &rem_bw_rep);
 		}
 
+		// print local and remote separately, if separate reporting was requested
+		// and a duplex test was run
 		if (user_param.report_both && user_param.duplex) {
 			printf(RESULT_LINE);
 			printf("\n Local results: \n");
@@ -443,6 +446,11 @@ int main(int argc, char *argv[])
 			printf((user_param.report_fmt == MBS ? RESULT_FMT : RESULT_FMT_G));
 			printf((user_param.cpu_util_data.enable ? RESULT_EXT_CPU_UTIL : RESULT_EXT));
 			print_full_bw_report(&user_param, &rem_bw_rep, NULL);
+		}
+
+		// print JSON, if requested
+		if (user_param.out_json) {
+			print_full_bw_report_to_file(&user_param, &my_bw_rep, &rem_bw_rep);
 		}
 	} else if (user_param.test_method == RUN_INFINITELY) {
 


### PR DESCRIPTION
# Changes

- Add `"results_local"` and `"results_remote"` keys to the JSON when `--bidirectional` and `--report-both` are turned on
	- This is in addition to the already-existing `"results"` key when either of those flags are turned off.
	- These key names mimic the output to STDOUT when `--bidirectional` and `--report-both` are turned on
- Fix bug where different JSONs were being written and rewritten to the same path, up to three times 
	- If `--bidirectional` and `--report-both` are both given, then `print_full_bw_report()` was being called three times, and each time it would write out the JSON
	- This means that: first it would write a JSON with the combined results, then it would write a JSON with the local results, then it would write a JSON with the remote results, and you'd be left only with the remote results, because it would overwrite itself each time (with no indication that this happened)
- Refactor the code a bit to make this all possible:
	- Make a dedicated function for writing out the bandwidth JSON, so we can avoid calling it three times
	- Make a helper function for summing two bandwidth reports, for reporting the aggregate results

---

# Example

```
ib_send_bw --bidirectional --report_gbits --report-both --size=8388608
```

```
{
"test_info": {
"test": "Send_Bidirectional_BW_Test",
"Dual_port": "OFF",
"Device": "mlx5_0",
"Number_of_qps": 1,
"Transport_type": "IB",
"Connection_type": "RC",
"Using_SRQ": "OFF",
"PCIe_relax_order": "ON",
"ibv_wr_API": "ON",
"TX_depth": 128,
"RX_depth": 512,
"CQ_Moderation": 1,
"Mtu": 4096,
"Link_type": "IB",
"Max_inline_data": 0,
"rdma_cm_QPs": "OFF",
"Use_ROCm_memory": "OFF",
"Data_ex_method": "Ethernet"
},
"results": {
"MsgSize": 8388608,
"n_iterations": 1000,
"BW_peak": 709.85,
"BW_average": 674.06,
"MsgRate": 0.010044
},
"results_local": {
"MsgSize": 8388608,
"n_iterations": 1000,
"BW_peak": 346.67,
"BW_average": 331.96,
"MsgRate": 0.004947
},
"results_remote": {
"MsgSize": 8388608,
"n_iterations": 1000,
"BW_peak": 363.18,
"BW_average": 342.10,
"MsgRate": 0.005098
}
}
```