### PR TITLE
Fix compile warning when ibv_wr_api disabled

### DIFF
--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -1396,7 +1396,7 @@ int create_comm_struct(struct perftest_comm *comm,
 
 	return SUCCESS;
 
-free_mem: __attribute__((unused))
+free_mem:
 	#ifdef HAVE_DCS
 	free(comm->rdma_ctx->dci_stream_id);
 	#endif
@@ -1406,7 +1406,7 @@ free_qpx: __attribute__((unused))
 	free(comm->rdma_ctx->qpx);
 	#endif
 // cppcheck-suppress unusedLabelConfiguration
-free_qp:
+free_qp: __attribute__((unused))
 	free(comm->rdma_ctx->qp);
 free_buf:
 	free(comm->rdma_ctx->buf);


### PR DESCRIPTION
bash autogen.sh
./configure --disable-ibv_wr_api
make

this warning occurs:
src/perftest_communication.c: In function ‘create_comm_struct’: src/perftest_communication.c:1359:1: warning: label ‘free_qp’ defined but not used [-Wunused-label]

In the code, free_mem could not be unused, while free_qp could in certain macro branches.