### PR TITLE
Perftest: Fix address cycling bug in local address increment logic

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -3369,7 +3369,7 @@ int ctx_set_recv_wqes(struct pingpong_context *ctx,struct perftest_parameters *u
 				if ((user_param->tst == BW || user_param->tst == LAT_BY_BW) && user_param->size <= (ctx->cycle_buffer / 2)) {
 					increase_loc_addr(&ctx->recv_sge_list[i * user_param->recv_post_list + j],
 							user_param->size,
-							j,
+							j-1,
 							ctx->rx_buffer_addr[i],
 							user_param->connection_type,ctx->cache_line_size,ctx->cycle_buffer);
 				}


### PR DESCRIPTION
The increase_loc_addr() function manages circular buffer addressing. One of the input argument is rcnt, which represents the number of post_send/post_receive operations that were called per QP. Based on rcnt, it internally calculates the local address for the next operation. When setting up receive WQEs, this function is being called with the index of the current operation instead of the amount that was already called. This incorrect indexing caused the last WQE in the buffer to incorrectly point to the first WQE's address in the QP. This bug affects the cyclic address calculation used for cache-efficient data placement. The fix ensures proper address cycling by passing the correct index to the function.

Reviewed-by: Firas Jahjah <firasj@amazon.com>
Reviewed-by: Daniel Kranzdorf <dkkranzd@amazon.com>