### PR TITLE
chore: make completion error outputs more descriptive

### DIFF
--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -107,12 +107,14 @@
 
 #define NOTIFY_COMP_ERROR_SEND(wc,scnt,ccnt)                     											\
 	{ fprintf(stderr," Completion with error at client\n");      											\
-	  fprintf(stderr," Failed status %d: qp_num %d wr_id %d syndrom 0x%x\n",wc.status,(int) wc.qp_num,(int) wc.wr_id,wc.vendor_err);	\
-	  fprintf(stderr, "scnt=%lu, ccnt=%lu\n",scnt, ccnt); }
+	  fprintf(stderr," Failed status-%s (%d): wr_id %d syndrom 0x%x\n",      								\
+	          ibv_wc_status_str(wc.status),wc.status,(int) wc.wr_id,wc.vendor_err);      					\
+	  fprintf(stderr," scnt=%lu, ccnt=%lu\n",scnt, ccnt); }
 
 #define NOTIFY_COMP_ERROR_RECV(wc,rcnt)                     											    \
 	{ fprintf(stderr," Completion with error at server\n");      											\
-	  fprintf(stderr," Failed status %d: qp_num %d wr_id %d syndrom 0x%x\n",wc.status,(int) wc.qp_num,(int) wc.wr_id,wc.vendor_err);	\
+	  fprintf(stderr," Failed status-%s (%d): wr_id %d syndrom 0x%x\n",      								\
+	          ibv_wc_status_str(wc.status),wc.status,(int) wc.wr_id,wc.vendor_err);      					\
 	  fprintf(stderr," rcnt=%lu\n",rcnt); }
 
 /* Macro to determine packet size in case of UD. The UD addition is for the GRH . */


### PR DESCRIPTION
Output description string of WC error status directly, which makes it easier for users to get the reasons (e.g. retry counter exceeded) without needing to refer to the codes.

```
---------------------------------------------------------------------------------------
                    RDMA_Write BW Test
 Dual-port       : OFF          Device         : mlx5_0
 Number of qps   : 1            Transport type : IB
 Connection type : RC           Using SRQ      : OFF
 PCIe relax order: ON           Lock-free      : OFF
 ibv_wr* API     : OFF          Using DDP      : OFF
 TX depth        : 128
 CQ Moderation   : 1
 Mtu             : 4096[B]
 Link type       : Ethernet
 GID index       : 0
 Max inline data : 0[B]
 rdma_cm QPs     : ON
 Data ex. method : rdma_cm
---------------------------------------------------------------------------------------
 local address: LID 0000 QPN 0x27d8 PSN 0x79f042
 GID: 00:00:00:00:00:00:00:00:00:00:255:255:192:168:01:39
 remote address: LID 0000 QPN 0x1c901 PSN 0x6726b1
 GID: 00:00:00:00:00:00:00:00:00:00:255:255:192:168:01:06
---------------------------------------------------------------------------------------
 #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]
 65536      403504           0.00               42.31                0.080701
 65536      247166           0.00               25.92                0.049433
 65536      0           0.000000            0.000000            0.000000
 Completion with error at client
 Failed status-transport retry counter exceeded (12): wr_id 0 syndrom 0x0
 scnt=668523, ccnt=668523
 Error occurred while running infinitely! aborting ...
```