### PR TITLE
Extended MR fix for providers which don't support extended.

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1832,7 +1832,7 @@ static int register_memory_region(struct pingpong_context *ctx,
 
 	mr = register_func(ctx, user_param, qp_index, flags, dmabuf_fd, dmabuf_offset);
 
-	if (!mr && errno == EPROTONOSUPPORT && register_func != register_mr) {
+	if (!mr && errno == EOPNOTSUPP && register_func != register_mr) {
 		/* If extended registration is not supported, fall back to standard registration */
 		register_func = register_mr;
 		mr = register_func(ctx, user_param, qp_index, flags, dmabuf_fd, dmabuf_offset);


### PR DESCRIPTION
Check for the right errno that returned when mr_reg_ex is not implemented by the provider. It tested EPROTONOSUPPORT but it should have tested for EOPNOTSUPP.

Reviewed-by: Yonatan Nachum <ynachum@amazon.com>
Reviewed-by: Yossi Leybovich <sleybo@amazon.com>