### PR TITLE
Perftest: Provide clearer error message for specifying QP number in non bw test

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -2846,7 +2846,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				  user_param->use_gid_user = 1; break;
 			case 'c': change_conn_type(&user_param->connection_type,user_param->verb,optarg); break;
 			case 'q': if (user_param->tst != BW) {
-					fprintf(stderr," Multiple QPs only available on bw tests\n");
+					fprintf(stderr," Specify QP number is only available on bw tests\n");
 					free(duplicates_checker);
 					return FAILURE;
 				  }


### PR DESCRIPTION
Original message says that multiple QPs is only available for bw test, but even if user uses `-q 1`, it would still fail and print error, which doesn't match with the message. Change that message to a clearer expression.