### PR TITLE
perftest: enable CQ events support for WRITE_IMM operations

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -321,7 +321,7 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 	printf("  -D, --duration ");
 	printf(" Run test for a customized period of seconds. (SYMMETRIC)\n");
 
-	if (verb != WRITE && verb != WRITE_IMM && connection_type != RawEth) {
+	if (verb != WRITE && connection_type != RawEth) {
 		printf("  -e, --events ");
 		printf(" Sleep on CQ events (default poll)\n");
 
@@ -1790,6 +1790,12 @@ static void force_dependecies(struct perftest_parameters *user_param)
 		}
 	}
 
+	if (user_param->use_event == ON && user_param->verb == WRITE) {
+		printf(RESULT_LINE);
+		fprintf(stderr," Events feature not available on WRITE verb\n");
+		exit(1);
+	}
+
 	if ((user_param->use_srq && (user_param->tst == LAT || user_param->machine == SERVER || user_param->duplex == ON)) || user_param->use_xrc)
 		user_param->srq_exists = 1;
 
@@ -2949,12 +2955,8 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 					  return FAILURE;
 				  }
 				  break;
-			case 'e': user_param->use_event = ON;
-				  if (user_param->verb == WRITE || user_param->verb == WRITE_IMM) {
-					  fprintf(stderr," Events feature not available on WRITE verb\n");
-					  free(duplicates_checker);
-					  return FAILURE;
-				  }
+			case 'e':
+				  user_param->use_event = ON;
 				  break;
 			case 'X':
 				  if (user_param->verb == WRITE || user_param->verb == WRITE_IMM) {

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -5064,7 +5064,7 @@ int run_iter_lat_write_imm(struct pingpong_context *ctx,struct perftest_paramete
 	uint64_t                scnt = 0;
 	uint64_t                ccnt = 0;
 	uint64_t                rcnt = 0;
-	int                     ne;
+	int                     ne = 0;
 	int			err = 0;
 	volatile char           *post_buf = NULL;
 
@@ -5111,8 +5111,15 @@ int run_iter_lat_write_imm(struct pingpong_context *ctx,struct perftest_paramete
 		if ((rcnt < user_param->iters || user_param->test_type == DURATION) && !(scnt < 1 && user_param->machine == SERVER)) {
 			rcnt++;
 
+			if (user_param->use_event) {
+				if (ctx_notify_events(ctx->recv_channel)) {
+					fprintf(stderr , " Failed to notify events to CQ\n");
+					return 1;
+				}
+			}
+
 			/* Poll for a completion */
-			do { ne = ibv_poll_cq(ctx->recv_cq, 1, &wc); } while (ne == 0 && !(user_param->test_type == DURATION && user_param->state == END_STATE));
+			do { ne = ibv_poll_cq(ctx->recv_cq, 1, &wc); } while (!user_param->use_event && ne == 0 && !(user_param->test_type == DURATION && user_param->state == END_STATE));
 			if (ne > 0) {
 				if (wc.status != IBV_WC_SUCCESS) {
 					//coverity[uninit_use_in_call]
@@ -5171,6 +5178,13 @@ int run_iter_lat_write_imm(struct pingpong_context *ctx,struct perftest_paramete
 			break;
 
 		if (ccnt < user_param->iters || user_param->test_type == DURATION) {
+
+			if (user_param->use_event && ne == 0) {
+				if (ctx_notify_events(ctx->send_channel)) {
+					fprintf(stderr, "Couldn't request CQ notification\n");
+					return 1;
+				}
+			}
 
 			do { ne = ibv_poll_cq(ctx->send_cq, 1, &wc); } while (ne == 0);
 

--- a/src/write_bw.c
+++ b/src/write_bw.c
@@ -222,6 +222,17 @@ int main(int argc, char *argv[])
 		ctx_print_pingpong_data(&rem_dest[i],&user_comm);
 	}
 
+	if (user_param.use_event) {
+		if (ibv_req_notify_cq(ctx.send_cq, 0)) {
+			fprintf(stderr, " Couldn't request CQ notification\n");
+			goto destroy_context;
+		}
+		if (ibv_req_notify_cq(ctx.recv_cq, 0)) {
+			fprintf(stderr, " Couldn't request CQ notification\n");
+			goto destroy_context;
+		}
+	}
+
 	/* An additional handshake is required after moving qp to RTR. */
 	if (ctx_hand_shake(&user_comm,&my_dest[0],&rem_dest[0])) {
 		fprintf(stderr," Failed to exchange data between server and clients\n");

--- a/src/write_lat.c
+++ b/src/write_lat.c
@@ -243,6 +243,17 @@ int main(int argc, char *argv[])
 		ctx_print_pingpong_data(&rem_dest[i],&user_comm);
 	}
 
+	if (user_param.use_event) {
+		if (ibv_req_notify_cq(ctx.send_cq, 0)) {
+			fprintf(stderr, " Couldn't request CQ notification\n");
+			goto destroy_context;
+		}
+		if (ibv_req_notify_cq(ctx.recv_cq, 0)) {
+			fprintf(stderr, " Couldn't request CQ notification\n");
+			goto destroy_context;
+		}
+	}
+
 	/* An additional handshake is required after moving qp to RTR. */
 	if (ctx_hand_shake(&user_comm,my_dest,rem_dest)) {
 		fprintf(stderr,"Failed to exchange data between server and clients\n");


### PR DESCRIPTION
Remove the restriction that prevented WRITE_IMM operations from using
completion queue events. As WRITE_IMM posts to the reciever CQ, there's
no reason not to support the event parameter (-e) as in WRITE.

Changes include:
- Remove WRITE_IMM exclusion from events parameter parsing
- Add CQ notification setup for write_bw and write_lat tools
- Implement event notification in run_iter_lat_write_imm()
- Update polling logic to respect use_event flag