### PR TITLE
Fix use of cuCtxCreate with Cuda 13.0 and newer

### DIFF
--- a/src/cuda_loader.c
+++ b/src/cuda_loader.c
@@ -10,7 +10,11 @@ CUresult (*p_cuDeviceGetCount)(int *) = NULL;
 CUresult (*p_cuDeviceGet)(CUdevice *, int) = NULL;
 CUresult (*p_cuDeviceGetAttribute)(int *, CUdevice_attribute, CUdevice) = NULL;
 CUresult (*p_cuDeviceGetName)(char *, int, CUdevice) = NULL;
+#if CUDA_VER >= 13000
+CUresult (*p_cuCtxCreate)(CUcontext *, CUctxCreateParams *, unsigned int, CUdevice) = NULL;
+#else
 CUresult (*p_cuCtxCreate)(CUcontext *, unsigned int, CUdevice) = NULL;
+#endif
 CUresult (*p_cuDevicePrimaryCtxRetain)(CUcontext *, CUdevice) = NULL;
 CUresult (*p_cuCtxSetCurrent)(CUcontext) = NULL;
 CUresult (*p_cuCtxDestroy)(CUcontext) = NULL;

--- a/src/cuda_loader.h
+++ b/src/cuda_loader.h
@@ -30,7 +30,11 @@ extern CUresult (*p_cuDeviceGetCount)(int *);
 extern CUresult (*p_cuDeviceGet)(CUdevice *, int);
 extern CUresult (*p_cuDeviceGetAttribute)(int *, CUdevice_attribute, CUdevice);
 extern CUresult (*p_cuDeviceGetName)(char *, int, CUdevice);
+#if CUDA_VER >= 13000
+extern CUresult (*p_cuCtxCreate)(CUcontext *, CUctxCreateParams *, unsigned int, CUdevice);
+#else
 extern CUresult (*p_cuCtxCreate)(CUcontext *, unsigned int, CUdevice);
+#endif
 extern CUresult (*p_cuDevicePrimaryCtxRetain)(CUcontext *, CUdevice);
 extern CUresult (*p_cuCtxSetCurrent)(CUcontext);
 extern CUresult (*p_cuCtxDestroy)(CUcontext);

--- a/src/cuda_memory.c
+++ b/src/cuda_memory.c
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /*
- * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2023-2025 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #include <stdio.h>
@@ -96,7 +96,11 @@ static int init_gpu(struct cuda_memory_ctx *ctx)
 	printf("creating CUDA Ctx\n");
 
 	/* Create context */
+#if CUDA_VER >= 13000
+	error = p_cuCtxCreate(&ctx->cuContext, NULL, CU_CTX_MAP_HOST, ctx->cuDevice);
+#else
 	error = p_cuCtxCreate(&ctx->cuContext, CU_CTX_MAP_HOST, ctx->cuDevice);
+#endif
 	if (error != CUDA_SUCCESS) {
 		printf("cuCtxCreate() error=%d\n", error);
 		return FAILURE;


### PR DESCRIPTION
cuCtxCreate function signature was changed from:
CUresult cuCtxCreate(CUcontext* pctx, unsigned int flags, CUdevice dev)

To:
CUresult cuCtxCreate(CUcontext* pctx, CUctxCreateParams* ctxCreateParams, unsigned int flags, CUdevice dev)

in cuda 13.0 which causes perftest compilation to fail. Add support for the new function signature using the CUDA_VER which stores the configured against Cuda version.