### PR TITLE
Perftest: Add Pensando device support

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -2162,6 +2162,8 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 			case 0x1610 : dev_fname = NBL_RNIC400; break; /* RNIC400 */
 			default     : dev_fname = NBL_LEONIS;
 		}
+	} else if (attr.vendor_id == 0x1dd8) {
+		dev_fname = PENSANDO_ALL;
 	} else {
 
 		//coverity[uninit_use]

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -395,6 +395,7 @@ enum ctx_device {
 	NBL_DRACO		= 39,
 	NBL_DF200		= 40,
 	NBL_RNIC400		= 41,
+	PENSANDO_ALL		= 42,
 };
 
 /* Units for rate limiter */


### PR DESCRIPTION
Adds the PENSANDO_ALL device (vendor_id 0x1dd8)