### PR TITLE
Fix MR registration for providers which don't support extended

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1902,7 +1902,8 @@ static int register_memory_region(struct pingpong_context *ctx,
 
 	mr = register_func(ctx, user_param, qp_index, flags, dmabuf_fd, dmabuf_offset);
 
-	if (!mr && errno == EPROTONOSUPPORT && register_func != register_mr) {
+	if (!mr && (errno == EOPNOTSUPP || errno == EPROTONOSUPPORT) &&
+	    register_func != register_mr) {
 		/* If extended registration is not supported, fall back to standard registration */
 		register_func = register_mr;
 		mr = register_func(ctx, user_param, qp_index, flags, dmabuf_fd, dmabuf_offset);


### PR DESCRIPTION
Check for the right errno that returned from the missing implementation.