### PR TITLE
Fix set max_rd_atomic respecting the local device limit

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -3061,7 +3061,7 @@ static int ctx_modify_qp_to_rts(struct ibv_qp *qp,
 			attr->timeout   = user_param->qp_timeout;
 			attr->retry_cnt = 7;
 			attr->rnr_retry = 7;
-			attr->max_rd_atomic  = dest->out_reads;
+			attr->max_rd_atomic  = MIN(dest->out_reads, my_dest->out_reads);
 			flags |= (IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY | IBV_QP_MAX_QP_RD_ATOMIC);
 		}
 	}


### PR DESCRIPTION
When configuring max_rd_atomic account for our device's constraint in cases where the destination's max_qp_rd_atom (from ibv_devinfo -v) exceeds our local limit.