### PR TITLE
Data Validation for Perftest

### DIFF
--- a/man/perftest.1
+++ b/man/perftest.1
@@ -472,10 +472,11 @@ many different options and modes.
  Use write-with-immediate verb instead of write.
  Write tests only.
 .TP
-.B --data_validation=<random|serial>
+.B --data_validation=<random|serial|pattern>
 Perform data validation on transferred packets.
  random: Data is randomized.
  serial: Data is filled with sequential numeric series. Use --data_start_value=<N> to set starting point.
+ pattern: Data is filled using contents of file provided by --payload_file_path=<file>.
 .TP
 .B --data_start_value
 Starting value for serial data validation. Set to 0 by default.

--- a/man/perftest.1
+++ b/man/perftest.1
@@ -472,9 +472,13 @@ many different options and modes.
  Use write-with-immediate verb instead of write.
  Write tests only.
 .TP
-.B --data_validation=<random>
+.B --data_validation=<random|serial>
 Perform data validation on transferred packets.
  random: Data is randomized.
+ serial: Data is filled with sequential numeric series. Use --data_start_value=<N> to set starting point.
+.TP
+.B --data_start_value
+Starting value for serial data validation. Set to 0 by default.
 .SS RawEth only options
 .TP
 .B -B, --source_mac

--- a/man/perftest.1
+++ b/man/perftest.1
@@ -471,6 +471,10 @@ many different options and modes.
 .B --write_with_imm
  Use write-with-immediate verb instead of write.
  Write tests only.
+.TP
+.B --data_validation=<random>
+Perform data validation on transferred packets.
+ random: Data is randomized.
 .SS RawEth only options
 .TP
 .B -B, --source_mac

--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -308,7 +308,7 @@ static int ethernet_write_keys(struct pingpong_dest *my_dest,
 	} else {
 		char msg[KEY_MSG_SIZE_GID];
 		sprintf(msg,KEY_PRINT_FMT_GID, my_dest->lid,my_dest->out_reads,
-				my_dest->qpn,my_dest->psn, my_dest->rkey, my_dest->vaddr,
+				my_dest->qpn,my_dest->psn, my_dest->rkey, my_dest->vaddr, my_dest->data_validation_hint,
 				my_dest->gid.raw[0],my_dest->gid.raw[1],
 				my_dest->gid.raw[2],my_dest->gid.raw[3],
 				my_dest->gid.raw[4],my_dest->gid.raw[5],
@@ -403,6 +403,12 @@ static int ethernet_read_keys(struct pingpong_dest *rem_dest,
 		tmp[term - pstr] = 0;
 
 		rem_dest->vaddr = strtoull(tmp, NULL, 16); /*VA*/
+
+		pstr += term - pstr + 1;
+		term = strpbrk(pstr, ":");
+		memcpy(tmp, pstr, term - pstr);
+		tmp[term - pstr] = 0;
+		rem_dest->data_validation_hint = (uint32_t)strtoul(tmp, NULL, 16); /*DATA_VALIDATION_HINT*/
 
 		for (i = 0; i < 15; ++i) {
 			pstr += term - pstr + 1;

--- a/src/perftest_communication.h
+++ b/src/perftest_communication.h
@@ -73,14 +73,14 @@
 #define hton_int(x) (int) htonl((uint32_t) (x))
 
 #define KEY_MSG_SIZE 	 (59)   /* Message size without gid. */
-#define KEY_MSG_SIZE_GID (108)   /* Message size with gid (MGID as well). */
+#define KEY_MSG_SIZE_GID (129)   /* Message size with gid (MGID as well). */
 #define SYNC_SPEC_ID	 (5)
 
 /* The Format of the message we pass through sockets , without passing Gid. */
 #define KEY_PRINT_FMT "%04x:%04x:%06x:%06x:%08x:%016llx:%08x"
 
 /* The Format of the message we pass through sockets (With Gid). */
-#define KEY_PRINT_FMT_GID "%04x:%04x:%06x:%06x:%08x:%016llx:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%08x:"
+#define KEY_PRINT_FMT_GID "%04x:%04x:%06x:%06x:%08x:%016llx:%08x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x:%08x:"
 
 /* The Basic print format for all verbs. */
 #define BASIC_ADDR_FMT " %s address: LID %#04x QPN %#06x PSN %#06x"

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -406,7 +406,7 @@ enum rate_limiter_units {MEGA_BYTE_PS, GIGA_BIT_PS, PACKET_PS};
 enum rate_limiter_types {HW_RATE_LIMIT, SW_RATE_LIMIT, PP_RATE_LIMIT, DISABLE_RATE_LIMIT};
 
 /*Types data validation*/
-enum data_validation_types {NONE, RANDOM, SERIAL};
+enum data_validation_types {NONE, RANDOM, SERIAL, PATTERN};
 
 /* Verbosity Levels for test report */
 enum verbosity_level {FULL_VERBOSITY=-1, OUTPUT_BW=0, OUTPUT_MR, OUTPUT_LAT };

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -406,7 +406,7 @@ enum rate_limiter_units {MEGA_BYTE_PS, GIGA_BIT_PS, PACKET_PS};
 enum rate_limiter_types {HW_RATE_LIMIT, SW_RATE_LIMIT, PP_RATE_LIMIT, DISABLE_RATE_LIMIT};
 
 /*Types data validation*/
-enum data_validation_types {NONE, RANDOM};
+enum data_validation_types {NONE, RANDOM, SERIAL};
 
 /* Verbosity Levels for test report */
 enum verbosity_level {FULL_VERBOSITY=-1, OUTPUT_BW=0, OUTPUT_MR, OUTPUT_LAT };
@@ -690,6 +690,7 @@ struct perftest_parameters {
 	int				dynamic_cqe_poll;
 	int				sig_offload;
 	enum data_validation_types 	data_validation;
+	uint32_t			data_start_value;
 };
 
 struct report_options {

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -405,6 +405,9 @@ enum rate_limiter_units {MEGA_BYTE_PS, GIGA_BIT_PS, PACKET_PS};
 /*Types rate limit*/
 enum rate_limiter_types {HW_RATE_LIMIT, SW_RATE_LIMIT, PP_RATE_LIMIT, DISABLE_RATE_LIMIT};
 
+/*Types data validation*/
+enum data_validation_types {NONE, RANDOM};
+
 /* Verbosity Levels for test report */
 enum verbosity_level {FULL_VERBOSITY=-1, OUTPUT_BW=0, OUTPUT_MR, OUTPUT_LAT };
 
@@ -686,6 +689,7 @@ struct perftest_parameters {
 	int				processing_hints;
 	int				dynamic_cqe_poll;
 	int				sig_offload;
+	enum data_validation_types 	data_validation;
 };
 
 struct report_options {

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -1904,7 +1904,11 @@ static void generate_buffer_data(struct pingpong_context *ctx,
 		if (user_param->machine == SERVER) {
 			current_data = ctx->data_validation_hint;
 		} else {
-			current_data = init_perftest_rand_state();
+			if (user_param->data_validation == SERIAL) {
+				current_data = user_param->data_start_value;
+			} else {
+				current_data = init_perftest_rand_state();
+			}
 			ctx->data_validation_hint = current_data;
 		}
 	} else {
@@ -1917,7 +1921,12 @@ static void generate_buffer_data(struct pingpong_context *ctx,
 		}
 	} else {
 		for (i = 0; i < ctx->buff_size/4; i++) {
-			buf_ptr[i] = htonl(perftest_rand(&current_data));
+			if (user_param->data_validation == SERIAL) {
+				buf_ptr[i] = htonl(current_data);
+				current_data++;
+			} else {
+				buf_ptr[i] = htonl(perftest_rand(&current_data));
+			}
 		}
 	}
 }

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -476,7 +476,8 @@ static inline int _new_post_send(struct pingpong_context *ctx,
 			ibv_wr_rdma_write_imm(
 				ctx->qpx[index],
 				wr->wr.rdma.rkey,
-				wr->wr.rdma.remote_addr, 0);
+				wr->wr.rdma.remote_addr,
+				wr->imm_data);
 			break;
 		case IBV_WR_RDMA_READ:
 			ibv_wr_rdma_read(
@@ -1156,7 +1157,6 @@ int alloc_ctx(struct pingpong_context *ctx,struct perftest_parameters *user_para
 {
 	uint64_t tarr_size;
 	int num_of_qps_factor;
-	ctx->cycle_buffer = user_param->cycle_buffer;
 	ctx->cache_line_size = user_param->cache_line_size;
 
 	ALLOC(user_param->port_by_qp, uint64_t, user_param->num_of_qps);
@@ -1189,6 +1189,9 @@ int alloc_ctx(struct pingpong_context *ctx,struct perftest_parameters *user_para
 	#endif
 	ALLOC(ctx->mr, struct ibv_mr*, user_param->num_of_qps);
 	ALLOC(ctx->buf, void*, user_param->num_of_qps);
+	if (user_param->data_validation && user_param->machine == SERVER) {
+		ALLOC(ctx->validation_buf, void*, user_param->num_of_qps);
+	}
 
 	if ((user_param->tst == BW || user_param->tst == LAT_BY_BW) && (user_param->machine == CLIENT || user_param->duplex)) {
 
@@ -1231,8 +1234,17 @@ int alloc_ctx(struct pingpong_context *ctx,struct perftest_parameters *user_para
 			 user_param->num_of_qps * user_param->recv_post_list);
 		ALLOC(ctx->rx_buffer_addr, uint64_t, user_param->num_of_qps);
 	}
-	if (user_param->mac_fwd == ON )
+
+	if (user_param->mac_fwd == ON ) {
 		ctx->cycle_buffer = user_param->size * user_param->rx_depth;
+	} else if (user_param->data_validation) {
+		if (user_param->machine == CLIENT)
+			ctx->cycle_buffer = INC(user_param->size, ctx->cache_line_size) * user_param->post_list;
+		else
+			ctx->cycle_buffer = INC(user_param->size, ctx->cache_line_size) * user_param->recv_post_list;
+	} else {
+		ctx->cycle_buffer = user_param->cycle_buffer;
+	}
 
 	ctx->size = user_param->size;
 
@@ -1307,6 +1319,11 @@ void dealloc_ctx(struct pingpong_context *ctx,struct perftest_parameters *user_p
 		free(ctx->mr);
 	if (ctx->buf != NULL)
 		free(ctx->buf);
+	if (user_param->machine == SERVER && ctx->validation_buf != NULL) {
+		if (ctx->validation_buf[0])
+			ctx->memory->free_buffer(ctx->memory, 0, ctx->validation_buf[0], ctx->buff_size);
+		free(ctx->validation_buf);
+	}
 	if ((user_param->tst == BW || user_param->tst == LAT_BY_BW) && (user_param->machine == CLIENT || user_param->duplex)) {
 		if (ctx->my_addr != NULL)
 			free(ctx->my_addr);
@@ -1875,28 +1892,48 @@ static int setup_mr_flags(struct perftest_parameters *user_param)
 	return flags;
 }
 
+static void generate_buffer_data(struct pingpong_context *ctx,
+				 struct perftest_parameters *user_param,
+				 void* buf)
+{
+	uint64_t i;
+	uint32_t *buf_ptr = (uint32_t*)buf;
+	uint32_t current_data;
+
+	if (user_param->data_validation) {
+		if (user_param->machine == SERVER) {
+			current_data = ctx->data_validation_hint;
+		} else {
+			current_data = init_perftest_rand_state();
+			ctx->data_validation_hint = current_data;
+		}
+	} else {
+		current_data = init_perftest_rand_state();
+	}
+
+	if (user_param->has_payload_modification) {
+		for (i = 0; i < ctx->buff_size; i++) {
+			((char*)buf)[i] = user_param->payload_content[i % user_param->payload_length];
+		}
+	} else {
+		for (i = 0; i < ctx->buff_size/4; i++) {
+			buf_ptr[i] = htonl(perftest_rand(&current_data));
+		}
+	}
+}
+
 static void initialize_buffer_content(struct pingpong_context *ctx,
 				      struct perftest_parameters *user_param,
-				      int qp_index, bool can_init_mem)
+				      void* buf, bool can_init_mem)
 {
 	if (!can_init_mem)
 		return;
 
-	uint32_t rng_state = init_perftest_rand_state();
-	if ((user_param->verb == WRITE || user_param->verb == WRITE_IMM) && user_param->tst == LAT) {
-		memset(ctx->buf[qp_index], 0, ctx->buff_size);
+	if (((user_param->verb == WRITE || user_param->verb == WRITE_IMM) && user_param->tst == LAT) ||
+	    (user_param->data_validation && user_param->machine == SERVER)) {
+		memset(buf, 0, ctx->buff_size);
 	} else {
-		uint64_t i;
-		if (user_param->has_payload_modification) {
-			for (i = 0; i < ctx->buff_size; i++) {
-				((char*)ctx->buf[qp_index])[i] = user_param->payload_content[i % user_param->payload_length];
-			}
-		} else {
-			uint32_t *buf_ptr = (uint32_t*)ctx->buf[qp_index];
-			for (i = 0; i < ctx->buff_size/4; i++) {
-				buf_ptr[i] = perftest_rand(&rng_state);
-			}
-		}
+		generate_buffer_data(ctx, user_param, buf);
 	}
 }
 
@@ -2069,7 +2106,7 @@ int create_single_mr(struct pingpong_context *ctx, struct perftest_parameters *u
 	}
 
 	/* Initialize buffer content */
-	initialize_buffer_content(ctx, user_param, qp_index, can_init_mem);
+	initialize_buffer_content(ctx, user_param, ctx->buf[qp_index], can_init_mem);
 
 	return SUCCESS;
 }
@@ -2155,6 +2192,27 @@ static int create_payload(struct perftest_parameters *user_param)
 	return 0;
 }
 
+int create_data_validation_reference_buffer(struct pingpong_context *ctx, struct perftest_parameters *user_param) {
+	bool can_init_mem = true;
+	int dmabuf_fd = 0;
+	uint64_t dmabuf_offset;
+
+	if (ctx->memory->allocate_buffer(ctx->memory, user_param->cycle_buffer, ctx->buff_size,
+					 &dmabuf_fd, &dmabuf_offset, &ctx->validation_buf[0],
+					 &can_init_mem)) {
+		return FAILURE;
+	}
+
+	generate_buffer_data(ctx, user_param, ctx->validation_buf[0]);
+
+	for (int i = 1; i < user_param->num_of_qps; i++) {
+		ctx->validation_buf[i] = ctx->validation_buf[0] + (i * INC(user_param->size, ctx->cache_line_size) * user_param->tx_depth);
+	}
+
+	return SUCCESS;
+}
+
+
 /******************************************************************************
  *
  ******************************************************************************/
@@ -2186,8 +2244,13 @@ int create_mr(struct pingpong_context *ctx, struct perftest_parameters *user_par
 			mr_index++;
 		} else {
 			ctx->mr[i] = ctx->mr[0];
-			// cppcheck-suppress arithOperationsOnVoidPointer
-			ctx->buf[i] = ctx->buf[0] + (i*BUFF_SIZE(ctx->size, ctx->cycle_buffer));
+			if (user_param->machine == CLIENT || !user_param->data_validation) {
+				// cppcheck-suppress arithOperationsOnVoidPointer
+				ctx->buf[i] = ctx->buf[0] + (i*BUFF_SIZE(ctx->size, ctx->cycle_buffer));
+			} else {
+				// cppcheck-suppress arithOperationsOnVoidPointer
+				ctx->buf[i] = ctx->buf[0] + (user_param->num_of_qps + i) * ctx->send_qp_buff_size;
+			}
 		}
 	}
 
@@ -3602,7 +3665,8 @@ void ctx_set_send_reg_wqes(struct pingpong_context *ctx,
 
 				ctx->sge_list[i*user_param->post_list +j].addr = ctx->sge_list[i*user_param->post_list + (j-1)].addr;
 
-				if ((user_param->tst == BW || user_param->tst == LAT_BY_BW) && user_param->size <= (ctx->cycle_buffer / 2))
+				if (((user_param->tst == BW || user_param->tst == LAT_BY_BW) && user_param->size <= (ctx->cycle_buffer / 2)) ||
+						user_param->data_validation)
 					increase_loc_addr(&ctx->sge_list[i*user_param->post_list +j],user_param->size,
 							j-1,ctx->my_addr[i],0,ctx->cache_line_size,ctx->cycle_buffer);
 			}
@@ -3610,6 +3674,14 @@ void ctx_set_send_reg_wqes(struct pingpong_context *ctx,
 			ctx->wr[i*user_param->post_list + j].sg_list = &ctx->sge_list[i*user_param->post_list + j];
 			ctx->wr[i*user_param->post_list + j].num_sge = MAX_SEND_SGE;
 			ctx->wr[i*user_param->post_list + j].wr_id   = build_wr_id(i * user_param->post_list + j, i);
+
+			/* In data validation the immediate field is used to send the address offset
+			 * from the beginning of the QP buffer for the receiver to know where to start
+			 * to validate from in the validation reference buffer.
+			 */
+			if (user_param->data_validation) {
+				ctx->wr[i*user_param->post_list + j].imm_data = ctx->sge_list[i*user_param->post_list +j].addr - (uintptr_t)ctx->buf[i];
+			}
 
 			if (j == (user_param->post_list - 1)) {
 				ctx->wr[i*user_param->post_list + j].next = NULL;
@@ -3639,7 +3711,8 @@ void ctx_set_send_reg_wqes(struct pingpong_context *ctx,
 					ctx->wr[i*user_param->post_list + j].wr.rdma.remote_addr =
 						ctx->wr[i*user_param->post_list + (j-1)].wr.rdma.remote_addr;
 
-					if ((user_param->tst == BW || user_param->tst == LAT_BY_BW ) && user_param->size <= (ctx->cycle_buffer / 2))
+					if (((user_param->tst == BW || user_param->tst == LAT_BY_BW ) && user_param->size <= (ctx->cycle_buffer / 2)) ||
+							user_param->data_validation)
 						increase_rem_addr(&ctx->wr[i*user_param->post_list + j],user_param->size,
 								j-1,ctx->rem_addr[i],WRITE,ctx->cache_line_size,ctx->cycle_buffer);
 				}
@@ -3751,7 +3824,8 @@ int ctx_set_recv_wqes(struct pingpong_context *ctx,struct perftest_parameters *u
 			if (j > 0) {
 				ctx->recv_sge_list[i * user_param->recv_post_list + j].addr = ctx->recv_sge_list[i * user_param->recv_post_list + j - 1].addr;
 
-				if ((user_param->tst == BW || user_param->tst == LAT_BY_BW) && user_param->size <= (ctx->cycle_buffer / 2)) {
+				if (((user_param->tst == BW || user_param->tst == LAT_BY_BW) && user_param->size <= (ctx->cycle_buffer / 2)) ||
+						user_param->data_validation) {
 					increase_loc_addr(&ctx->recv_sge_list[i * user_param->recv_post_list + j],
 							user_param->size,
 							j-1,
@@ -4259,6 +4333,10 @@ int run_iter_bw_server(struct pingpong_context *ctx, struct perftest_parameters 
 	uintptr_t		primary_recv_addr = ctx->recv_sge_list[0].addr;
 	int			recv_flows_burst = 0;
 	int			address_flows_offset =0;
+	uint32_t		recv_offset;
+	uint32_t		data_length;
+	uint64_t		expected_data_addr;
+	uint64_t		actual_data_addr;
 
 	struct dyn_poll_ctx *dyn_ctx = init_dyn_poll_ctx(user_param);
 	if (!dyn_ctx) {
@@ -4336,6 +4414,20 @@ int run_iter_bw_server(struct pingpong_context *ctx, struct perftest_parameters 
 						return_value = FAILURE;
 						goto cleaning;
 					}
+
+					if (user_param->data_validation) {
+							recv_offset = wc[i].imm_data;
+							data_length = wc[i].byte_len;
+							expected_data_addr = (uint64_t)ctx->validation_buf[qp_index] + recv_offset;
+							actual_data_addr =  ctx->rx_buffer_addr[qp_index] + recv_offset;
+
+							if (memcmp((void*)expected_data_addr, (void*)actual_data_addr, data_length)) {
+								fprintf(stderr, "Data validation comparison failed.\n");
+								return_value = FAILURE;
+								goto cleaning;
+							}
+					}
+
 					rcnt_for_qp[qp_index]++;
 					rcnt++;
 					unused_recv_for_qp[qp_index]++;

--- a/src/perftest_resources.h
+++ b/src/perftest_resources.h
@@ -301,6 +301,8 @@ struct pingpong_context {
 	#ifdef HAVE_REG_MR_EX
 	struct ibv_dmah				*dmah;
 	#endif
+	uint32_t	 			data_validation_hint;
+	void					**validation_buf;
 };
 
  struct pingpong_dest {
@@ -313,6 +315,7 @@ struct pingpong_context {
 	union ibv_gid			gid;
 	unsigned			srqn;
 	int				gid_index;
+	uint32_t			data_validation_hint;
  };
 
 /******************************************************************************
@@ -984,6 +987,23 @@ int create_single_mr(struct pingpong_context *ctx,
  */
 int create_mr(struct pingpong_context *ctx,
 		struct perftest_parameters *user_param);
+
+/* create_data_validation_reference_buffer
+ *
+ * Description :
+ *
+ *	Creates a memory buffer to be used for data validation scenarios.
+ *	Takes into consideration all user parameters and test type.
+ *
+ *	Parameters :
+ *			ctx - Resources sructure.
+ *			user_param - the perftest parameters.
+ *
+ * Return Value : SUCCESS, FAILURE.
+ *
+ */
+int create_data_validation_reference_buffer(struct pingpong_context *ctx,
+	struct perftest_parameters *user_param);
 
 /* alloc_hugapage_region
  *

--- a/src/write_bw.c
+++ b/src/write_bw.c
@@ -222,10 +222,22 @@ int main(int argc, char *argv[])
 		ctx_print_pingpong_data(&rem_dest[i],&user_comm);
 	}
 
+	if (user_param.machine == CLIENT && user_param.data_validation) {
+		my_dest->data_validation_hint = ctx.data_validation_hint;
+	}
+
 	/* An additional handshake is required after moving qp to RTR. */
 	if (ctx_hand_shake(&user_comm,&my_dest[0],&rem_dest[0])) {
 		fprintf(stderr," Failed to exchange data between server and clients\n");
 		goto destroy_context;
+	}
+
+	if (user_param.machine == SERVER && user_param.data_validation) {
+		ctx.data_validation_hint = rem_dest->data_validation_hint;
+		if (create_data_validation_reference_buffer(&ctx, &user_param)) {
+			fprintf(stderr," Failed to allocate and randomize data validation buffer at server side\n");
+			goto free_mem;
+		}
 	}
 
 	if (user_param.output == FULL_VERBOSITY) {


### PR DESCRIPTION
This patch series adds data validation capability to perftest for write_bw test scenarios, enabling verification of data integrity during RDMA write operations.

Data validation complements perftest's performance testing by providing functional correctness verification. This is valuable for validating new hardware, drivers, or firmware deployments, debugging intermittent data corruption issues under load, and ensuring RDMA configurations work correctly before production use. The feature is disabled by default and only activated via explicit flags, ensuring no impact on standard performance testing workflows.

Three validation modes are supported:
- random: Randomized data generation
- serial: Sequential numeric series with configurable starting value
- pattern: Custom patterns from input file

Usage:
  --data_validation <random|serial|pattern>
  --data_start_value <N>           (for serial mode, default: 0)
  --payload_file_path <file>       (for pattern mode)

Requirements:
- Must use write_bw with --write_with_imm flag
- post_list (-l) must equal tx_depth (-t)
- recv_post_list must equal rx_depth (-r)

The immediate field is used to pass buffer offset hints for validation. Server-side validation compares expected vs actual data and reports mismatches.

Patches:
1. Perftest: Write BW random data validation
2. Perftest: Write BW serial data validation
3. Perftest: Write BW pattern data validation