### PR TITLE
perftest_communication: Fixed memory region alignment when message size is not a multiple of cache line size

### DIFF
--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -909,9 +909,9 @@ int set_up_connection(struct pingpong_context *ctx,
 		/* Each qp gives his receive buffer address.*/
 		my_dest[i].out_reads = user_param->out_reads;
 		if (user_param->mr_per_qp)
-			my_dest[i].vaddr = (uintptr_t)ctx->buf[i] + BUFF_SIZE(ctx->size,ctx->cycle_buffer);
+			my_dest[i].vaddr = (uintptr_t)ctx->buf[i] + INC(BUFF_SIZE(ctx->size,ctx->cycle_buffer), ctx->cache_line_size);
 		else
-			my_dest[i].vaddr = (uintptr_t)ctx->buf[0] + (user_param->num_of_qps + i)*BUFF_SIZE(ctx->size,ctx->cycle_buffer);
+			my_dest[i].vaddr = (uintptr_t)ctx->buf[0] + (user_param->num_of_qps + i)*INC(BUFF_SIZE(ctx->size,ctx->cycle_buffer), ctx->cache_line_size);
 
 		if (user_param->dualport==ON) {
 


### PR DESCRIPTION
Fixes #361

I'm not very familiar with the code, please check if this a valid fix with no side effects, and whether there are other places where this alignment is missing.

Thanks and have a nice day!
