### PR TITLE
Perftest: Handle timeout CM DREQ event

### DIFF
--- a/src/perftest_communication.c
+++ b/src/perftest_communication.c
@@ -2816,8 +2816,13 @@ int rdma_cm_event_error_handler(struct pingpong_context *ctx,
 /******************************************************************************
 *
 ******************************************************************************/
-void rdma_cm_disconnect_handler(struct pingpong_context *ctx)
+void rdma_cm_disconnect_handler(struct pingpong_context *ctx,
+				struct rdma_cm_event *event)
 {
+	if(event->status != 0) {
+		fprintf(stderr, "RDMA CM disconnect event received with error status: %d\n", event->status);
+	}
+	fflush(stderr);
 	ctx->cma_master.disconnects_left--;
 }
 
@@ -2851,7 +2856,7 @@ int rdma_cm_events_dispatcher(struct pingpong_context *ctx,
 		rc = rdma_cm_event_error_handler(ctx, event);
 		break;
 	case RDMA_CM_EVENT_DISCONNECTED:
-		rdma_cm_disconnect_handler(ctx);
+		rdma_cm_disconnect_handler(ctx, event);
 		break;
 	case RDMA_CM_EVENT_DEVICE_REMOVAL:
 		/* Cleanup will occur after test completes. */

--- a/src/perftest_communication.h
+++ b/src/perftest_communication.h
@@ -725,12 +725,14 @@ int rdma_cm_event_error_handler(struct pingpong_context *ctx,
 * Parameters:
 *
 *    ctx - Application contexts.
+*    event - RDMA CM event.
 *
 * Return value:
 *    None.
 *
 */
-void rdma_cm_disconnect_handler(struct pingpong_context *ctx);
+void rdma_cm_disconnect_handler(struct pingpong_context *ctx,
+		struct rdma_cm_event *event);
 
 /* rdma_cm_events_dispatcher:
 *


### PR DESCRIPTION
A DREQ could timeout during RDMA CM disconnection. This is reflected by a event status field marked by IB core. Userspace application like perftest should check that in order to handle disconnection events correctly.