### PR TITLE
autotools: fix potential shell syntax errors in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,7 +81,7 @@ AC_CHECK_LIB([ibumad], [umad_init], [LIBUMAD=-libumad], AC_MSG_ERROR([libibumad 
 AC_CHECK_LIB([m], [log], [LIBMATH=-lm], AC_MSG_ERROR([libm not found]))
 
 AC_CHECK_LIB([ibverbs], [ibv_reg_dmabuf_mr], [HAVE_REG_DMABUF_MR=yes], [HAVE_REG_DMABUF_MR=no])
-if test $HAVE_REG_DMABUF_MR = yes; then
+if test "x$HAVE_REG_DMABUF_MR" = "xyes"; then
 	AC_DEFINE([HAVE_REG_DMABUF_MR], [1], [Enable HAVE_REG_DMABUF_MR])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -681,8 +681,8 @@ AC_SUBST([SIMD_CFLAGS])
 CFLAGS="-g -Wall -D_GNU_SOURCE -O3 $CFLAGS"
 LDFLAGS="$LDFLAGS"
 LIBS=$LIBS" -lpthread"
-AM_CONDITIONAL([OPENCL], [test "$HAVE_OPENCL"])
-if [test $HAVE_OPENCL = yes]; then
+AM_CONDITIONAL([OPENCL], [test "x$HAVE_OPENCL" = "xyes"])
+if [test "x$HAVE_OPENCL" = "xyes"]; then
 	AC_DEFINE([HAVE_OPENCL], [1], [Enable OPENCL feature])
 	AC_CHECK_LIB([OpenCL], [clGetDeviceIDs], [], [AC_MSG_ERROR([libOpenCL not found])])
 fi


### PR DESCRIPTION
# Description
This PR fixes a potential shell script syntax error in `configure.ac` by adopting a more robust string comparison pattern for the `HAVE_REG_DMABUF_MR` check.

## The Problem
The existing check used a direct variable expansion:
`if test $HAVE_REG_DMABUF_MR = yes; then`

If `$HAVE_REG_DMABUF_MR` is empty or undefined, the shell evaluates the expression as `if test = yes; then`. This causes a **"unary operator expected"** error during the execution of the `./configure` script, potentially halting the build process or leading to incorrect configuration states.

## The Fix
I have updated the conditional to use the defensive `"x$VAR" = "xyes"` idiom. 
* **Quoting:** Handles cases where the variable is empty or contains whitespace.
* **The "x" Prefix:** Prevents the shell from misinterpreting the variable content as a command-line flag (e.g., if the variable contained `-n`).
