### PR TITLE
write_bw: guard data_validation_destroy in cleanup path

### DIFF
--- a/src/write_bw.c
+++ b/src/write_bw.c
@@ -591,7 +591,8 @@ int main(int argc, char *argv[])
 		return SUCCESS;
 	}
 
-	data_validation_destroy(&ctx);
+	if (user_param.data_validation)
+		data_validation_destroy(&ctx);
 	free(rem_dest);
 	free(my_dest);
 	free(user_param.ib_devname);


### PR DESCRIPTION
This fixes a cleanup crash in `write_bw` when running with `--use_rocm` without `--data_validation`.

Previously, `write_bw` called `data_validation_destroy(&ctx)` unconditionally in the normal cleanup path. For memory backends that do not implement data validation, this could reach an uninitialized optional callback and crash during cleanup.