### PR TITLE
Added --enable-num_sge_zero in configure.ac to allow for using num_sge=0 for Write with IMM if the vendor supports it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,11 @@ AS_IF([test "x$enable_cq_ex" = "xno"],
       [USE_CQ_EX=no],
         [USE_CQ_EX=yes])
 
+AC_ARG_ENABLE([num_sge_zero],
+  [AS_HELP_STRING([--enable-num_sge_zero], [Allows using num_sge=0 with RDMA Write With IMM verb])],
+  [AC_DEFINE([HAVE_NUM_SGE_ZERO], [1], [Use num_sge=0 with RDMA Write With IMM])],
+  [])
+	
 AC_PREFIX_DEFAULT("/usr")
 
 AC_PROG_CC

--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -4099,11 +4099,15 @@ int ctx_set_recv_wqes(struct pingpong_context *ctx,struct perftest_parameters *u
 				}
 			}
 
+#ifdef HAVE_NUM_SGE_ZERO
+// Setting num_sge=0 is supported by the vendor and using it for WRITE_IMM verb.
 			if (user_param->verb == WRITE_IMM) {
 				ctx->rwr[i * user_param->recv_post_list + j].sg_list = NULL;
 				ctx->rwr[i * user_param->recv_post_list + j].num_sge = 0;
 			}
-			else {
+			else 
+#endif
+			{
 				ctx->rwr[i * user_param->recv_post_list + j].sg_list = &ctx->recv_sge_list[i * user_param->recv_post_list + j];
 				ctx->rwr[i * user_param->recv_post_list + j].num_sge = MAX_RECV_SGE;
 			}


### PR DESCRIPTION
Added --enable-num_sge_zero in configure.ac to allow for using num_sge=0 for Write with IMM if the vendor supports it.

Following up on the action item in PR: https://github.com/linux-rdma/perftest/pull/387