### PR TITLE
Add vendor-id and change inline size for nebula-matrix rdma nic

### DIFF
--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -2358,13 +2358,29 @@ enum ctx_device ib_dev_name(struct ibv_context *context)
 		}
 	} else if (attr.vendor_id == 0x1f0f) {
 		switch (attr.vendor_part_id) {
-			case 0x340b : dev_fname = NBL_LEONIS; break; /* leonis snic v3r1 pf */
+			case 0x340B : dev_fname = NBL_LEONIS; break; /* leonis snic v3r1 pf */
+			case 0x340C : dev_fname = NBL_LEONIS; break;
+			case 0x340D : dev_fname = NBL_LEONIS; break;
+			case 0x340E : dev_fname = NBL_LEONIS; break;
+			case 0x340F : dev_fname = NBL_LEONIS; break;
+			case 0x3410 : dev_fname = NBL_LEONIS; break;
+			case 0x3411 : dev_fname = NBL_LEONIS; break;
+			case 0x3412 : dev_fname = NBL_LEONIS; break;
 			case 0x3413 : dev_fname = NBL_LEONIS; break; /* leonis snic v3r1 vf nbl_dev */
 			case 0x1047 : dev_fname = NBL_DF200; break; /* DF200 */
 			case 0x1226 : dev_fname = NBL_DF200; break; /* DF200 */
 			case 0x1227 : dev_fname = NBL_DF200; break; /* DF200 */
 			case 0x3500 : dev_fname = NBL_DRACO; break; /* draco use same inline size with df200 */
 			case 0x3501 : dev_fname = NBL_DRACO; break;
+			case 0x3502 : dev_fname = NBL_DRACO; break;
+			case 0x3503 : dev_fname = NBL_DRACO; break;
+			case 0x3504 : dev_fname = NBL_DRACO; break;
+			case 0x3505 : dev_fname = NBL_DRACO; break;
+			case 0x3506 : dev_fname = NBL_DRACO; break;
+			case 0x3507 : dev_fname = NBL_DRACO; break;
+			case 0x3508 : dev_fname = NBL_DRACO; break;
+			case 0x3509 : dev_fname = NBL_DRACO; break;
+			case 0x350A : dev_fname = NBL_DRACO; break;
 			case 0x1610 : dev_fname = NBL_RNIC400; break; /* RNIC400 */
 			default     : dev_fname = NBL_LEONIS;
 		}
@@ -2703,7 +2719,7 @@ static void ctx_set_max_inline(struct ibv_context *context,struct perftest_param
 				if (user_param->connection_type == UD)
 					user_param->inline_size = 0;
 				else
-					user_param->inline_size = 48;
+					user_param->inline_size = 32;
 			} else if (current_dev == NBL_DF200 || current_dev == NBL_DRACO || current_dev == NBL_RNIC400) {
                                 if (user_param->connection_type == UD)
                                         user_param->inline_size = 434;


### PR DESCRIPTION
1. Vendor-id add from 340B to 3412 for NBL_LEONIS, from 3502 to 350A for NBL_DRACO.
2.  NBL_LEONIS support inline_size 32.