### PR TITLE
Perftest: Add MUSA GPUDirect backend

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ AUTOMAKE_OPTIONS= subdir-objects
 
 noinst_LIBRARIES = libperftest.a
 libperftest_a_SOURCES = src/get_clock.c src/perftest_communication.c src/perftest_parameters.c src/perftest_resources.c src/perftest_counters.c src/host_memory.c src/host_validation.c src/mmap_memory.c
-noinst_HEADERS = src/get_clock.h src/perftest_communication.h src/perftest_parameters.h src/perftest_resources.h src/perftest_counters.h src/memory.h src/host_memory.h src/host_validation.h src/mmap_memory.h src/cuda_memory.h src/rocm_memory.h src/neuron_memory.h src/hl_memory.h src/mlu_memory.h src/cuda_validation.h src/validation_common.h src/dm_memory.h
+noinst_HEADERS = src/get_clock.h src/perftest_communication.h src/perftest_parameters.h src/perftest_resources.h src/perftest_counters.h src/memory.h src/host_memory.h src/host_validation.h src/mmap_memory.h src/cuda_memory.h src/rocm_memory.h src/neuron_memory.h src/hl_memory.h src/mlu_memory.h src/cuda_validation.h src/validation_common.h src/dm_memory.h src/musa_memory.h
 
 AM_CFLAGS =
 
@@ -44,6 +44,10 @@ src/host_validation.$(OBJEXT): CFLAGS += @SIMD_CFLAGS@
 
 if CUDA
 libperftest_a_SOURCES += src/cuda_memory.c src/cuda_loader.h src/cuda_loader.c
+endif
+
+if MUSA
+libperftest_a_SOURCES += src/musa_memory.c src/musa_loader.h src/musa_loader.c
 endif
 
 if ROCM

--- a/README
+++ b/README
@@ -258,6 +258,17 @@ Special feature detailed explanation in tests:
      Thus --use_cuda=<gpu_index> flag will be available to add to a command line:
      ./ib_write_bw -d ib_dev --use_cuda=<gpu index> -a
 
+     MUSA (Moore Threads Support) GPUDirect support follows the same dynamic
+     loading model as CUDA. If musa.h is not installed in
+     /usr/local/musa/include, pass MUSA_H_PATH to configure:
+     ./autogen.sh && ./configure MUSA_H_PATH=/usr/local/musa/include/musa.h && make -j
+
+     Thus --use_musa=<gpu_index> flag will be available to add to a command line:
+     ./ib_write_bw -d ib_dev --use_musa=<gpu index> --use_musa_dmabuf -a
+     MUSA device-memory ib_write_lat tests must use --write_with_imm explicitly
+     because plain RDMA WRITE latency requires CPU polling of the destination
+     buffer, which is not valid for MUSA device memory.
+
      If the CUDA libraries are not installed in a standard system path,
      set the LDFLAGS environment variable before building so the linker
      can locate them. For example:

--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,7 @@ AC_SUBST(MINOR_VERSION)
 
 AC_ARG_VAR(HAVE_OPENCL, opencl support)
 AC_ARG_VAR(CUDA_H_PATH, help-string)
+AC_ARG_VAR(MUSA_H_PATH, help-string)
 AC_ARG_ENABLE([cudart],
               [AS_HELP_STRING([--enable-cudart],
                               [Enable CUDA runtime support (default: auto-detect)])
@@ -449,6 +450,66 @@ AM_CONDITIONAL([CUDA_DMA_BUF_MAPPING_TYPE_PCIE_SUPPORT],[test "x$CUDA_DMA_BUF_MA
 AM_CONDITIONAL([CUDA], [test "$cuda_h_path"])
 AM_CONDITIONAL([HAVE_CUDA], [test "$cuda_h_path"])
 AM_CONDITIONAL([HAVE_CUDART], [test "x$enable_cudart" = "xyes"])
+
+# Check for MUSA header file in common locations.
+AC_MSG_CHECKING([for MUSA header file])
+musa_found=no
+musa_h_path=""
+
+if test -n "$MUSA_HOME" && test -f "$MUSA_HOME/include/musa.h"; then
+	musa_h_path="$MUSA_HOME/include/musa.h"
+	musa_found=yes
+	AC_MSG_RESULT([found at $musa_h_path])
+fi
+
+if test "$musa_found" = "no" && test -f "/usr/local/musa/include/musa.h"; then
+	musa_h_path="/usr/local/musa/include/musa.h"
+	musa_found=yes
+	AC_MSG_RESULT([found at $musa_h_path])
+fi
+
+# User defined MUSA header path.
+if test -f "$MUSA_H_PATH"; then
+	musa_h_path="$MUSA_H_PATH"
+	musa_found=yes
+	AC_MSG_RESULT([found at $musa_h_path])
+fi
+
+if test "$musa_found" = "yes"; then
+	AC_DEFINE([HAVE_MUSA], [1], [Enable MUSA feature])
+	AC_DEFINE_UNQUOTED([MUSA_PATH], "$musa_h_path", [Enable MUSA feature])
+
+	AC_CHECK_DECLS([muMemGetHandleForAddressRange],
+		[HAVE_MUSA_MUMEMGETHANDLEFORADDRESSRANGE=yes],
+		[HAVE_MUSA_MUMEMGETHANDLEFORADDRESSRANGE=no],
+		[[#include "$musa_h_path"]])
+
+	AC_TRY_COMPILE([
+	#include <$musa_h_path>],
+	[int x = MU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD|MU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED;],
+	[MUSA_DMA_BUF_PARAMETERS_SUPPORT=yes], [MUSA_DMA_BUF_PARAMETERS_SUPPORT=no])
+
+	if [test "x$HAVE_REG_DMABUF_MR" = "xyes"] && [test "x$HAVE_MUSA_MUMEMGETHANDLEFORADDRESSRANGE" = "xyes"] && [test "x$MUSA_DMA_BUF_PARAMETERS_SUPPORT" = "xyes"]; then
+		HAVE_MUSA_DMABUF=yes
+		AC_DEFINE([HAVE_MUSA_DMABUF], [1], [Enable MUSA DMABUF feature])
+	fi
+
+	AC_TRY_COMPILE([
+	#include <$musa_h_path>],
+	[int x = MU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;],
+	[MUSA_DMA_BUF_MAPPING_TYPE_PCIE_SUPPORT=yes], [MUSA_DMA_BUF_MAPPING_TYPE_PCIE_SUPPORT=no])
+
+	if [test "x$MUSA_DMA_BUF_MAPPING_TYPE_PCIE_SUPPORT" = "xyes"] && [test "x$HAVE_REG_DMABUF_MR" = "xyes"]; then
+		AC_DEFINE([HAVE_MUSA_DMABUF_MAPPING_TYPE_PCIE], [1], [Enable MUSA DMABUF handle mapping via PCIe BAR1])
+	fi
+else
+	AC_MSG_RESULT([not found])
+fi
+
+AM_CONDITIONAL([MUSA_DMA_BUF_PARAMETERS_SUPPORT],[test "x$MUSA_DMA_BUF_PARAMETERS_SUPPORT" = "xyes"])
+AM_CONDITIONAL([MUSA_DMA_BUF_MAPPING_TYPE_PCIE_SUPPORT],[test "x$MUSA_DMA_BUF_MAPPING_TYPE_PCIE_SUPPORT" = "xyes"])
+AM_CONDITIONAL([MUSA], [test "$musa_h_path"])
+AM_CONDITIONAL([HAVE_MUSA], [test "$musa_h_path"])
 
 AC_ARG_ENABLE([neuron],
               [AS_HELP_STRING([--enable-neuron],

--- a/man/perftest.1
+++ b/man/perftest.1
@@ -372,6 +372,28 @@ many different options and modes.
  Not relevant for raw_ethernet_fs_rate.
  System support required.
 .TP
+.B --use_musa=<musa device id>
+ Use MUSA specific device for GPUDirect RDMA testing.
+ Not relevant for raw_ethernet_fs_rate.
+ System support required.
+.TP
+.B --use_musa_bus_id=<musa full BUS id>
+ Use MUSA specific device, based on its full PCIe address, for GPUDirect RDMA testing.
+ Not relevant for raw_ethernet_fs_rate.
+ System support required.
+.TP
+.B --use_musa_dmabuf
+ Use MUSA DMA-BUF for GPUDirect RDMA testing.
+ Not relevant for raw_ethernet_fs_rate.
+ System support required.
+.TP
+.B --use_musa_pcie_mapping
+ Use MUSA DMABUF handle mapping via PCIe BAR1.
+ Not relevant for raw_ethernet_fs_rate.
+ System support required.
+.br
+ MUSA device-memory ib_write_lat tests must use --write_with_imm explicitly.
+.TP
 .B --use_hl=<hl device id>
  Use HabanaLabs specific device for HW accelerator direct RDMA testing.
  System support required.

--- a/src/musa_loader.c
+++ b/src/musa_loader.c
@@ -1,0 +1,99 @@
+#include "musa_loader.h"
+
+#include <dlfcn.h>
+#include <stdio.h>
+
+static void *musa_handle;
+
+MUresult (*p_muInit)(unsigned int);
+MUresult (*p_muDeviceGetCount)(int *);
+MUresult (*p_muDeviceGet)(MUdevice *, int);
+MUresult (*p_muDeviceGetAttribute)(int *, MUdevice_attribute, MUdevice);
+MUresult (*p_muDeviceGetName)(char *, int, MUdevice);
+MUresult (*p_muCtxCreate)(MUcontext *, unsigned int, MUdevice);
+MUresult (*p_muCtxSetCurrent)(MUcontext);
+MUresult (*p_muCtxDestroy)(MUcontext);
+MUresult (*p_muDeviceGetByPCIBusId)(MUdevice *, const char *);
+MUresult (*p_muMemAllocHost)(void **, size_t);
+MUresult (*p_muMemAlloc)(MUdeviceptr *, size_t);
+MUresult (*p_muMemFreeHost)(void *);
+MUresult (*p_muMemFree)(MUdeviceptr);
+MUresult (*p_muMemcpy)(MUdeviceptr, MUdeviceptr, size_t);
+MUresult (*p_muMemcpyDtoD)(MUdeviceptr, MUdeviceptr, size_t);
+#ifdef HAVE_MUSA_DMABUF
+MUresult (*p_muMemGetHandleForAddressRange)(void *, MUdeviceptr, size_t,
+					    MUmemRangeHandleType,
+					    unsigned long long);
+#endif
+
+static int load_musa_symbol(void **func_ptr, const char *func_name)
+{
+	*func_ptr = dlsym(musa_handle, func_name);
+	if (!*func_ptr) {
+		fprintf(stderr, "Failed to resolve %s: %s\n", func_name, dlerror());
+		return -1;
+	}
+
+	return 0;
+}
+
+int load_musa_library(void)
+{
+	static const char *libraries[] = {
+		"libmusa.so",
+		"libmusa.so.1",
+		NULL
+	};
+	static const MusaSymbol symbols[] = {
+		{ (void **)&p_muInit, "muInit" },
+		{ (void **)&p_muDeviceGetCount, "muDeviceGetCount" },
+		{ (void **)&p_muDeviceGet, "muDeviceGet" },
+		{ (void **)&p_muDeviceGetAttribute, "muDeviceGetAttribute" },
+		{ (void **)&p_muDeviceGetName, "muDeviceGetName" },
+		{ (void **)&p_muCtxCreate, "muCtxCreate" },
+		{ (void **)&p_muCtxSetCurrent, "muCtxSetCurrent" },
+		{ (void **)&p_muCtxDestroy, "muCtxDestroy" },
+		{ (void **)&p_muDeviceGetByPCIBusId, "muDeviceGetByPCIBusId" },
+		{ (void **)&p_muMemAllocHost, "muMemAllocHost" },
+		{ (void **)&p_muMemAlloc, "muMemAlloc" },
+		{ (void **)&p_muMemFreeHost, "muMemFreeHost" },
+		{ (void **)&p_muMemFree, "muMemFree" },
+		{ (void **)&p_muMemcpy, "muMemcpy" },
+		{ (void **)&p_muMemcpyDtoD, "muMemcpyDtoD" },
+#ifdef HAVE_MUSA_DMABUF
+		{ (void **)&p_muMemGetHandleForAddressRange, "muMemGetHandleForAddressRange" },
+#endif
+	};
+	size_t i;
+
+	if (musa_handle)
+		return 0;
+
+	for (i = 0; libraries[i]; i++) {
+		musa_handle = dlopen(libraries[i], RTLD_LAZY);
+		if (musa_handle)
+			break;
+	}
+
+	if (!musa_handle) {
+		fprintf(stderr, "Failed to load MUSA library: %s\n", dlerror());
+		return -1;
+	}
+
+	for (i = 0; i < sizeof(symbols) / sizeof(symbols[0]); i++) {
+		if (load_musa_symbol(symbols[i].func_ptr, symbols[i].name)) {
+			unload_musa_library();
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+void unload_musa_library(void)
+{
+	if (musa_handle) {
+		dlclose(musa_handle);
+		musa_handle = NULL;
+	}
+}

--- a/src/musa_loader.h
+++ b/src/musa_loader.h
@@ -1,0 +1,46 @@
+#ifndef MUSA_LOADER_H
+#define MUSA_LOADER_H
+
+#include <stddef.h>
+
+#include "config.h"
+#include MUSA_PATH
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	void **func_ptr;
+	const char *name;
+} MusaSymbol;
+
+extern MUresult (*p_muInit)(unsigned int);
+extern MUresult (*p_muDeviceGetCount)(int *);
+extern MUresult (*p_muDeviceGet)(MUdevice *, int);
+extern MUresult (*p_muDeviceGetAttribute)(int *, MUdevice_attribute, MUdevice);
+extern MUresult (*p_muDeviceGetName)(char *, int, MUdevice);
+extern MUresult (*p_muCtxCreate)(MUcontext *, unsigned int, MUdevice);
+extern MUresult (*p_muCtxSetCurrent)(MUcontext);
+extern MUresult (*p_muCtxDestroy)(MUcontext);
+extern MUresult (*p_muDeviceGetByPCIBusId)(MUdevice *, const char *);
+extern MUresult (*p_muMemAllocHost)(void **, size_t);
+extern MUresult (*p_muMemAlloc)(MUdeviceptr *, size_t);
+extern MUresult (*p_muMemFreeHost)(void *);
+extern MUresult (*p_muMemFree)(MUdeviceptr);
+extern MUresult (*p_muMemcpy)(MUdeviceptr, MUdeviceptr, size_t);
+extern MUresult (*p_muMemcpyDtoD)(MUdeviceptr, MUdeviceptr, size_t);
+#ifdef HAVE_MUSA_DMABUF
+extern MUresult (*p_muMemGetHandleForAddressRange)(void *, MUdeviceptr, size_t,
+						   MUmemRangeHandleType,
+						   unsigned long long);
+#endif
+
+int load_musa_library(void);
+void unload_musa_library(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MUSA_LOADER_H */

--- a/src/musa_memory.c
+++ b/src/musa_memory.c
@@ -1,0 +1,330 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2026 Moore Threads Technology Co. Ltd. All rights reserved.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "musa_loader.h"
+#include "musa_memory.h"
+#include "perftest_parameters.h"
+
+#define MUCHECK(stmt) \
+	do { \
+		MUresult result = (stmt); \
+		ASSERT(MUSA_SUCCESS == result); \
+	} while (0)
+
+#define ACCEL_PAGE_SIZE (64 * 1024)
+
+struct musa_memory_ctx {
+	struct memory_ctx base;
+	int device_id;
+	char *device_bus_id;
+	MUdevice mu_device;
+	MUcontext mu_context;
+	bool use_dmabuf;
+	bool use_pcie_mapping;
+};
+
+static int init_gpu(struct musa_memory_ctx *ctx)
+{
+	int device_count = 0;
+	int index;
+	MUdevice mu_device;
+	MUresult error;
+
+	printf("initializing MUSA\n");
+	error = p_muInit(0);
+	if (error != MUSA_SUCCESS) {
+		printf("muInit(0) returned %d\n", error);
+		return FAILURE;
+	}
+
+	error = p_muDeviceGetCount(&device_count);
+	if (error != MUSA_SUCCESS) {
+		printf("muDeviceGetCount() returned %d\n", error);
+		return FAILURE;
+	}
+
+	if (device_count == 0) {
+		printf("There are no available device(s) that support MUSA\n");
+		return FAILURE;
+	}
+
+	if (ctx->device_id >= device_count) {
+		fprintf(stderr, "No such device ID (%d) exists in system\n", ctx->device_id);
+		return FAILURE;
+	}
+
+	printf("Listing all MUSA devices in system:\n");
+	for (index = 0; index < device_count; index++) {
+		int pci_bus_id = 0;
+		int pci_device_id = 0;
+
+		MUCHECK(p_muDeviceGet(&mu_device, index));
+		p_muDeviceGetAttribute(&pci_bus_id, MU_DEVICE_ATTRIBUTE_PCI_BUS_ID, mu_device);
+		p_muDeviceGetAttribute(&pci_device_id, MU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, mu_device);
+		printf("MUSA device %d: PCIe address is %02X:%02X\n",
+		       index, (unsigned int)pci_bus_id, (unsigned int)pci_device_id);
+	}
+
+	printf("\nPicking device No. %d\n", ctx->device_id);
+	MUCHECK(p_muDeviceGet(&ctx->mu_device, ctx->device_id));
+
+	{
+		char name[128];
+
+		MUCHECK(p_muDeviceGetName(name, sizeof(name), ctx->device_id));
+		printf("[pid = %d, dev = %d] device name = [%s]\n", getpid(), ctx->mu_device, name);
+	}
+
+	printf("creating MUSA Ctx\n");
+	error = p_muCtxCreate(&ctx->mu_context, MU_CTX_MAP_HOST, ctx->mu_device);
+	if (error != MUSA_SUCCESS) {
+		printf("muCtxCreate() error=%d\n", error);
+		return FAILURE;
+	}
+
+	printf("making it the current MUSA Ctx\n");
+	error = p_muCtxSetCurrent(ctx->mu_context);
+	if (error != MUSA_SUCCESS) {
+		printf("muCtxSetCurrent() error=%d\n", error);
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+
+static void free_gpu(struct musa_memory_ctx *ctx)
+{
+	if (!ctx->mu_context)
+		return;
+
+	printf("destroying current MUSA Ctx\n");
+	MUCHECK(p_muCtxDestroy(ctx->mu_context));
+	ctx->mu_context = 0;
+}
+
+static int musa_memory_init(struct memory_ctx *ctx)
+{
+	struct musa_memory_ctx *musa_ctx = container_of(ctx, struct musa_memory_ctx, base);
+	int return_value;
+
+	if (load_musa_library()) {
+		printf("Failed to load MUSA library dynamically\n");
+		return FAILURE;
+	}
+
+	if (musa_ctx->device_bus_id) {
+		MUresult error;
+
+		printf("initializing MUSA\n");
+		error = p_muInit(0);
+		if (error != MUSA_SUCCESS) {
+			printf("muInit(0) returned %d\n", error);
+			return FAILURE;
+		}
+
+		printf("Finding PCIe BUS %s\n", musa_ctx->device_bus_id);
+		error = p_muDeviceGetByPCIBusId(&musa_ctx->device_id, musa_ctx->device_bus_id);
+		if (error != MUSA_SUCCESS) {
+			fprintf(stderr, "muDeviceGetByPCIBusId failed with error: %d; Failed to get PCI Bus ID (%s)\n",
+				error, musa_ctx->device_bus_id);
+			return FAILURE;
+		}
+		printf("Picking GPU number %d\n", musa_ctx->device_id);
+	}
+
+	return_value = init_gpu(musa_ctx);
+	if (return_value) {
+		fprintf(stderr, "Couldn't init GPU context: %d\n", return_value);
+		return FAILURE;
+	}
+
+#ifdef HAVE_MUSA_DMABUF
+	if (musa_ctx->use_dmabuf) {
+		int is_supported = 0;
+
+		MUCHECK(p_muDeviceGetAttribute(&is_supported,
+					       MU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED,
+					       musa_ctx->mu_device));
+		if (!is_supported) {
+			fprintf(stderr, "DMA-BUF is not supported on this GPU\n");
+			return FAILURE;
+		}
+	}
+#endif
+
+	return SUCCESS;
+}
+
+static int musa_memory_destroy(struct memory_ctx *ctx)
+{
+	struct musa_memory_ctx *musa_ctx = container_of(ctx, struct musa_memory_ctx, base);
+
+	free_gpu(musa_ctx);
+	free(musa_ctx);
+	unload_musa_library();
+
+	return SUCCESS;
+}
+
+static int musa_allocate_device_memory_buffer(struct musa_memory_ctx *musa_ctx, uint64_t size,
+					      int *dmabuf_fd, uint64_t *dmabuf_offset,
+					      void **addr, bool *can_init)
+{
+	size_t buf_size = (size + ACCEL_PAGE_SIZE - 1) & ~(ACCEL_PAGE_SIZE - 1);
+	int integrated = 0;
+	MUresult error;
+
+	p_muDeviceGetAttribute(&integrated, MU_DEVICE_ATTRIBUTE_INTEGRATED, musa_ctx->mu_device);
+	printf("MUSA device integrated: %X\n", (unsigned int)integrated);
+
+	if (integrated == 1) {
+		error = p_muMemAllocHost(addr, buf_size);
+		if (error != MUSA_SUCCESS) {
+			printf("muMemAllocHost error=%d\n", error);
+			return FAILURE;
+		}
+
+		printf("allocated GPU buffer address at %p\n", *addr);
+		*can_init = false;
+		return SUCCESS;
+	}
+
+	{
+		MUdeviceptr dptr;
+
+		error = p_muMemAlloc(&dptr, buf_size);
+		if (error != MUSA_SUCCESS) {
+			printf("muMemAlloc error=%d\n", error);
+			return FAILURE;
+		}
+
+		*addr = (void *)dptr;
+		*can_init = false;
+
+#ifdef HAVE_MUSA_DMABUF
+		if (musa_ctx->use_dmabuf) {
+			const size_t host_page_size = sysconf(_SC_PAGESIZE);
+			MUdeviceptr aligned_ptr = dptr & ~(host_page_size - 1);
+			uint64_t offset = dptr - aligned_ptr;
+			size_t aligned_size = (size + offset + host_page_size - 1) & ~(host_page_size - 1);
+			unsigned long long flags = 0;
+
+			printf("using DMA-BUF for GPU buffer address at %#llx aligned at %#llx with aligned size %zu\n",
+			       (unsigned long long)dptr, (unsigned long long)aligned_ptr, aligned_size);
+
+			if (musa_ctx->use_pcie_mapping) {
+#ifdef HAVE_MUSA_DMABUF_MAPPING_TYPE_PCIE
+				flags = MU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
+#else
+				printf("support for MU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE is missing\n");
+				return FAILURE;
+#endif
+			}
+
+			error = p_muMemGetHandleForAddressRange((void *)dmabuf_fd, aligned_ptr,
+								aligned_size,
+								MU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+								flags);
+			if (error != MUSA_SUCCESS) {
+				printf("muMemGetHandleForAddressRange error=%d\n", error);
+				return FAILURE;
+			}
+
+			*dmabuf_offset = offset;
+		}
+#endif
+	}
+
+	return SUCCESS;
+}
+
+static int musa_memory_allocate_buffer(struct memory_ctx *ctx, int alignment, uint64_t size,
+				       int *dmabuf_fd, uint64_t *dmabuf_offset,
+				       void **addr, bool *can_init)
+{
+	struct musa_memory_ctx *musa_ctx = container_of(ctx, struct musa_memory_ctx, base);
+	int error;
+
+	error = musa_allocate_device_memory_buffer(musa_ctx, size, dmabuf_fd,
+						  dmabuf_offset, addr, can_init);
+	if (error != SUCCESS)
+		return FAILURE;
+
+	printf("allocated MUSA buffer of %lu bytes at %p\n", size, *addr);
+	return SUCCESS;
+}
+
+static int musa_memory_free_buffer(struct memory_ctx *ctx, int dmabuf_fd, void *addr, uint64_t size)
+{
+	struct musa_memory_ctx *musa_ctx = container_of(ctx, struct musa_memory_ctx, base);
+	int integrated = 0;
+
+	p_muDeviceGetAttribute(&integrated, MU_DEVICE_ATTRIBUTE_INTEGRATED, musa_ctx->mu_device);
+
+	if (integrated == 1) {
+		printf("deallocating GPU buffer %p\n", addr);
+		p_muMemFreeHost(addr);
+	} else {
+		MUdeviceptr dptr = (MUdeviceptr)addr;
+
+		printf("deallocating GPU buffer %016llx\n", (unsigned long long)dptr);
+		p_muMemFree(dptr);
+	}
+
+	return SUCCESS;
+}
+
+static void *musa_memory_copy_host_buffer(void *dest, const void *src, size_t size)
+{
+	p_muMemcpy((MUdeviceptr)dest, (MUdeviceptr)src, size);
+	return dest;
+}
+
+static void *musa_memory_copy_buffer_to_buffer(void *dest, const void *src, size_t size)
+{
+	p_muMemcpyDtoD((MUdeviceptr)dest, (MUdeviceptr)src, size);
+	return dest;
+}
+
+bool musa_memory_supported()
+{
+	return true;
+}
+
+bool musa_memory_dmabuf_supported()
+{
+#ifdef HAVE_MUSA_DMABUF
+	return true;
+#else
+	return false;
+#endif
+}
+
+struct memory_ctx *musa_memory_create(struct perftest_parameters *params)
+{
+	struct musa_memory_ctx *ctx;
+
+	ALLOCATE(ctx, struct musa_memory_ctx, 1);
+	memset(ctx, 0, sizeof(struct musa_memory_ctx));
+
+	ctx->base.init = musa_memory_init;
+	ctx->base.destroy = musa_memory_destroy;
+	ctx->base.allocate_buffer = musa_memory_allocate_buffer;
+	ctx->base.free_buffer = musa_memory_free_buffer;
+	ctx->base.copy_host_to_buffer = musa_memory_copy_host_buffer;
+	ctx->base.copy_buffer_to_host = musa_memory_copy_host_buffer;
+	ctx->base.copy_buffer_to_buffer = musa_memory_copy_buffer_to_buffer;
+	ctx->device_id = params->musa_device_id;
+	ctx->device_bus_id = params->musa_device_bus_id;
+	ctx->use_dmabuf = params->use_musa_dmabuf;
+	ctx->use_pcie_mapping = params->use_musa_pcie_mapping;
+
+	return &ctx->base;
+}

--- a/src/musa_memory.h
+++ b/src/musa_memory.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2026 Moore Threads Technology Co. Ltd. All rights reserved.
+ */
+
+#ifndef MUSA_MEMORY_H
+#define MUSA_MEMORY_H
+
+#include "config.h"
+#include "memory.h"
+
+struct perftest_parameters;
+
+bool musa_memory_supported();
+bool musa_memory_dmabuf_supported();
+struct memory_ctx *musa_memory_create(struct perftest_parameters *params);
+
+#ifndef HAVE_MUSA
+
+inline bool musa_memory_supported()
+{
+	return false;
+}
+
+inline bool musa_memory_dmabuf_supported()
+{
+	return false;
+}
+
+inline struct memory_ctx *musa_memory_create(struct perftest_parameters *params)
+{
+	return NULL;
+}
+
+#endif
+
+#endif /* MUSA_MEMORY_H */

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -16,6 +16,7 @@
 #include "host_memory.h"
 #include "mmap_memory.h"
 #include "cuda_memory.h"
+#include "musa_memory.h"
 #include "rocm_memory.h"
 #include "neuron_memory.h"
 #include "hl_memory.h"
@@ -766,6 +767,21 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 			}
 		}
 
+		if (musa_memory_supported()) {
+			printf("      --use_musa=<musa device id>");
+			printf(" Use MUSA specific device for GPUDirect RDMA testing\n");
+
+			printf("      --use_musa_bus_id=<musa full BUS id>");
+			printf(" Use MUSA specific device, based on its full PCIe address, for GPUDirect RDMA testing\n");
+
+			if (musa_memory_dmabuf_supported()) {
+				printf("      --use_musa_dmabuf");
+				printf(" Use MUSA DMA-BUF for GPUDirect RDMA testing\n");
+				printf("      --use_musa_pcie_mapping");
+				printf(" Use MUSA DMABUF handle mapping via PCIe BAR1\n");
+			}
+		}
+
 		if (rocm_memory_supported()) {
 			printf("      --use_rocm=<rocm device id>");
 			printf(" Use selected ROCm device for GPUDirect RDMA testing\n");
@@ -1051,6 +1067,10 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->cuda_device_bus_id	= NULL;
 	user_param->use_cuda_dmabuf	= 0;
 	user_param->use_cuda_pcie_mapping = 0;
+	user_param->musa_device_id	= 0;
+	user_param->musa_device_bus_id	= NULL;
+	user_param->use_musa_dmabuf	= 0;
+	user_param->use_musa_pcie_mapping = 0;
 	user_param->use_rocm_dmabuf = 0;
 	user_param->use_data_direct	= 0;
 	user_param->cuda_mem_type       = CUDA_MEM_DEVICE;
@@ -2255,13 +2275,15 @@ static void force_dependecies(struct perftest_parameters *user_param)
 		exit(1);
 	}
 
-	if (user_param->memory_type == MEMORY_CUDA && user_param->tst == LAT && user_param->verb == WRITE) {
+	if ((user_param->memory_type == MEMORY_CUDA || user_param->memory_type == MEMORY_MUSA) &&
+	    user_param->tst == LAT && user_param->verb == WRITE) {
 		printf(RESULT_LINE);
-		fprintf(stderr, "Perftest doesn't support CUDA latency test with write (without immediate) verb\n");
+		fprintf(stderr, "Perftest doesn't support device memory latency test with write (without immediate) verb; use --write_with_imm\n");
 		exit(1);
 	}
 
-	if ((user_param->memory_type == MEMORY_CUDA || user_param->memory_type == MEMORY_DM) &&
+	if ((user_param->memory_type == MEMORY_CUDA || user_param->memory_type == MEMORY_MUSA ||
+	     user_param->memory_type == MEMORY_DM) &&
 	    user_param->verb == SEND && (user_param->size <= 64 || user_param->test_method == RUN_ALL)) {
 		printf(RESULT_LINE);
 		printf("Scatter2CQE (size <= 64) is not supported with device memory send tests: setting MLX5_SCATTER_TO_CQE=0\n");
@@ -2269,9 +2291,10 @@ static void force_dependecies(struct perftest_parameters *user_param)
 			exit(1);
 	}
 
-	if (user_param->memory_type == MEMORY_CUDA && (int)user_param->size <= user_param->inline_size) {
+	if ((user_param->memory_type == MEMORY_CUDA || user_param->memory_type == MEMORY_MUSA) &&
+	    (int)user_param->size <= user_param->inline_size) {
 		printf(RESULT_LINE);
-		fprintf(stderr,"Perftest doesn't support CUDA tests with inline messages\n");
+		fprintf(stderr,"Perftest doesn't support device memory tests with inline messages\n");
 		exit(1);
 	}
 
@@ -2833,9 +2856,9 @@ static void ctx_set_max_inline(struct ibv_context *context,struct perftest_param
 	}
 
 	if (user_param->inline_size == DEF_INLINE) {
-		if (user_param->memory_type == MEMORY_CUDA){
+		if (user_param->memory_type == MEMORY_CUDA || user_param->memory_type == MEMORY_MUSA){
 			user_param->inline_size = 0;
-			printf("Perftest doesn't supports CUDA tests with inline messages: inline size set to 0\n");
+			printf("Perftest doesn't supports device memory tests with inline messages: inline size set to 0\n");
 			return;
 		}
 
@@ -2962,6 +2985,10 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	static int use_cuda_pcie_mapping_flag = 0;
 	static int use_data_direct_flag = 0;
 	static int cuda_mem_type_flag = 0;
+	static int use_musa_flag = 0;
+	static int use_musa_bus_id_flag = 0;
+	static int use_musa_dmabuf_flag = 0;
+	static int use_musa_pcie_mapping_flag = 0;
 	static int use_rocm_flag = 0;
 	static int use_rocm_dmabuf_flag = 0;
 	static int use_neuron_flag = 0;
@@ -3164,6 +3191,10 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{ .name = "use_cuda_pcie_mapping", .has_arg = 0, .flag = &use_cuda_pcie_mapping_flag, .val = 1},
 			{ .name = "use_data_direct",	.has_arg = 0, .flag = &use_data_direct_flag, .val = 1},
 			{ .name = "cuda_mem_type",	.has_arg = 1, .flag = &cuda_mem_type_flag, .val = 1},
+			{ .name = "use_musa",		.has_arg = 1, .flag = &use_musa_flag, .val = 1},
+			{ .name = "use_musa_bus_id",	.has_arg = 1, .flag = &use_musa_bus_id_flag, .val = 1},
+			{ .name = "use_musa_dmabuf",	.has_arg = 0, .flag = &use_musa_dmabuf_flag, .val = 1},
+			{ .name = "use_musa_pcie_mapping", .has_arg = 0, .flag = &use_musa_pcie_mapping_flag, .val = 1},
 			{ .name = "use_rocm",		.has_arg = 1, .flag = &use_rocm_flag, .val = 1},
 			{ .name = "use_rocm_dmabuf",	.has_arg = 0, .flag = &use_rocm_dmabuf_flag, .val = 1},
 			{ .name = "use_neuron",		.has_arg = 1, .flag = &use_neuron_flag, .val = 1},
@@ -3627,6 +3658,8 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				/* We statically define memory type options so check if requested option is actually supported. */
 				if (((use_cuda_flag || use_cuda_bus_id_flag) && !cuda_memory_supported()) ||
 				    (use_cuda_dmabuf_flag && !cuda_memory_dmabuf_supported()) ||
+				    ((use_musa_flag || use_musa_bus_id_flag) && !musa_memory_supported()) ||
+				    (use_musa_dmabuf_flag && !musa_memory_dmabuf_supported()) ||
 				    (use_rocm_flag && !rocm_memory_supported()) ||
 				    (use_rocm_dmabuf_flag && !rocm_memory_dmabuf_supported()) ||
 				    (use_neuron_flag && !neuron_memory_supported()) ||
@@ -3648,6 +3681,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				    (mmap_file_flag || use_mlu_flag || use_neuron_flag || use_hl_flag ||
 						use_ib_dm_dmabuf_flag ||
 					 (use_rocm_flag && user_param->memory_type != MEMORY_ROCM) ||
+					 ((use_musa_flag || use_musa_bus_id_flag) && user_param->memory_type != MEMORY_MUSA) ||
 				     ((use_cuda_flag || use_cuda_bus_id_flag) && user_param->memory_type != MEMORY_CUDA))) {
 					fprintf(stderr, " Can't use multiple memory types\n");
 					return FAILURE;
@@ -3702,6 +3736,32 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 						return FAILURE;
 					}
 					cuda_mem_type_flag = 0;
+				}
+				if (use_musa_flag) {
+					CHECK_VALUE_NON_NEGATIVE(user_param->musa_device_id,int,"MUSA device",not_int_ptr);
+					user_param->memory_type = MEMORY_MUSA;
+					user_param->memory_create = musa_memory_create;
+					use_musa_flag = 0;
+				}
+				if (use_musa_bus_id_flag) {
+					user_param->musa_device_bus_id = strdup(optarg);
+					printf("Got PCIe address of: %s\n", user_param->musa_device_bus_id);
+					user_param->memory_type = MEMORY_MUSA;
+					user_param->memory_create = musa_memory_create;
+					use_musa_bus_id_flag = 0;
+				}
+				if (use_musa_dmabuf_flag) {
+					user_param->use_musa_dmabuf = 1;
+					if (user_param->memory_type != MEMORY_MUSA) {
+						fprintf(stderr, "MUSA DMA-BUF cannot be used without MUSA\n");
+						free(duplicates_checker);
+						return FAILURE;
+					}
+					use_musa_dmabuf_flag = 0;
+				}
+				if (use_musa_pcie_mapping_flag) {
+					user_param->use_musa_pcie_mapping = 1;
+					use_musa_pcie_mapping_flag = 0;
 				}
 				if (use_rocm_flag) {
 					CHECK_VALUE_NON_NEGATIVE(user_param->rocm_device_id,int,"ROCm device",not_int_ptr);
@@ -4314,6 +4374,10 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 		fprintf(stderr, " CUDA PCIe mapping requires DMA-BUF\n");
 		return FAILURE;
 	}
+	if (user_param->use_musa_pcie_mapping && !user_param->use_musa_dmabuf) {
+		fprintf(stderr, " MUSA PCIe mapping requires DMA-BUF\n");
+		return FAILURE;
+	}
 	if (optind == argc - 1) {
 		GET_STRING(user_param->servername,strdupa(argv[optind]));
 
@@ -4595,6 +4659,8 @@ void ctx_print_test_info(struct perftest_parameters *user_param)
 
 	if (rocm_memory_supported())
 		printf(" Use ROCm memory : %s\n", user_param->memory_type == MEMORY_ROCM ? "ON" : "OFF");
+	if (musa_memory_supported())
+		printf(" Use MUSA memory : %s\n", user_param->memory_type == MEMORY_MUSA ? "ON" : "OFF");
 
 	printf(" Data ex. method : %s",exchange_state[temp]);
 
@@ -4833,11 +4899,14 @@ static void write_test_info_to_file(int out_json_fds, struct perftest_parameters
 
 	if (user_param->memory_type == MEMORY_CUDA)
 		dprintf(out_json_fds, "\"cuda_device\": %d,\n",user_param->cuda_device_id);
+	if (user_param->memory_type == MEMORY_MUSA)
+		dprintf(out_json_fds, "\"musa_device\": %d,\n",user_param->musa_device_id);
 
 	if (user_param->use_rdma_cm)
 		temp = 1;
 
 	dprintf(out_json_fds, "\"Use_ROCm_memory\": \"%s\",\n", user_param->memory_type == MEMORY_ROCM ? "ON" : "OFF");
+	dprintf(out_json_fds, "\"Use_MUSA_memory\": \"%s\",\n", user_param->memory_type == MEMORY_MUSA ? "ON" : "OFF");
 
 	dprintf(out_json_fds, "\"Data_ex_method\": \"%s\"",exchange_state[temp]);
 

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -455,6 +455,7 @@ enum memory_type {
 	MEMORY_HOST,
 	MEMORY_MMAP,
 	MEMORY_CUDA,
+	MEMORY_MUSA,
 	MEMORY_ROCM,
 	MEMORY_NEURON,
 	MEMORY_HL,
@@ -615,6 +616,10 @@ struct perftest_parameters {
 	int				use_cuda_dmabuf;
 	int				use_cuda_pcie_mapping;
 	int				use_data_direct;
+	int				musa_device_id;
+	char				*musa_device_bus_id;
+	int				use_musa_dmabuf;
+	int				use_musa_pcie_mapping;
 	int				rocm_device_id;
 	int				use_rocm_dmabuf;
 	int				neuron_core_id;


### PR DESCRIPTION
Add a first-class Moore-Threads GPU Software Architecture MUSA memory backend that follows the CUDA dynamic loading model. The backend loads libmusa at runtime, supports device memory allocation, DMA-BUF export and PCIe mapping, and exposes MUSA GPUDirect command line options.

Reject plain RDMA WRITE latency tests with MUSA device memory to avoid CPU polling of GPU memory. Users must request write-with-imm explicitly for MUSA ib_write_lat.

## Validation

Validated on Moore Threads S5000 GPU cards with RDMA NICs.

Build and linkage:
- `./autogen.sh && ./configure MUSA_H_PATH=/usr/local/musa/include/musa.h && make -j$(nproc)` passed
- `ib_write_lat --help` shows the MUSA options
- `ldd ./ib_write_lat` does not show a direct `libmusa` dependency

Functional coverage:
- Host-memory baseline coverage passed for send/write/read/atomic bandwidth and latency tests
- MUSA DMA-BUF coverage passed for send/write/read/atomic bandwidth and latency tests
- MUSA `ib_write_lat --write_with_imm` passed for 2, 7408, and 8192 byte messages
- Plain MUSA `ib_write_lat` without `--write_with_imm` fails cleanly with:
  `Perftest doesn't support device memory latency test with write (without immediate) verb; use --write_with_imm`
- Invalid option combinations fail cleanly:
  - `--use_musa_dmabuf` without MUSA
  - `--use_musa_pcie_mapping` without DMA-BUF

Selected MUSA DMA-BUF results:

| Test | Size | QPs | Result |
| --- | ---: | ---: | ---: |
| `ib_send_bw` | 8192 | 1 | 130.48 Gb/s |
| `ib_send_bw` | 8192 | 4 | 168.35 Gb/s |
| `ib_write_bw` | 7408 | 4 | 83.79 Gb/s |
| `ib_write_bw` | 7408 | 16 | 153.83 Gb/s |
| `ib_write_bw` | 8192 | 4 | 169.15 Gb/s |
| `ib_write_bw` | 8192 | 16 | 367.29 Gb/s |
| `ib_read_bw` | 8192 | 4 | 308.07 Gb/s |
| `ib_read_bw` | 8192 | 16 | 368.69 Gb/s |
| `ib_send_lat` | 2 | - | 6.25 usec |
| `ib_write_lat --write_with_imm` | 2 | - | 6.24 usec |
| `ib_write_lat --write_with_imm` | 7408 | - | 7.06 usec |
| `ib_write_lat --write_with_imm` | 8192 | - | 7.00 usec |
| `ib_read_lat` | 2 | - | 10.63 usec |
| `ib_read_lat` | 8192 | - | 11.26 usec |
| `ib_atomic_lat` | 8 | - | 10.62 usec |