### PR TITLE
Fix send credit wr_id encoding for multi-QP iWARP ib_send_bw

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -4324,7 +4324,7 @@ int ctx_set_credit_wqes(struct pingpong_context *ctx,
 		ctx->ctrl_wr[i].opcode = IBV_WR_RDMA_WRITE;
 		ctx->ctrl_wr[i].sg_list = &ctx->ctrl_sge_list[i];
 		ctx->ctrl_wr[i].num_sge = 1;
-		ctx->ctrl_wr[i].wr_id = i;
+		ctx->ctrl_wr[i].wr_id = build_wr_id(i, i);
 		ctx->ctrl_wr[i].send_flags = IBV_SEND_SIGNALED;
 		ctx->ctrl_wr[i].next = NULL;
 


### PR DESCRIPTION
Commit 1b396b1 ("Replacing wr_id usage with qp_index") moved all WQEs to a packed wr_id where the QP index is stored in bits 32-47 and is read back with get_wr_id_qp_index(). The data and receive WQEs were converted, but the send-credit WQEs were left encoding the plain QP index (ctx->ctrl_wr[i].wr_id = i).

The credit completion handlers in run_iter_bw_server() and run_iter_bw_infinitely_server() decode the QP index with get_wr_id_qp_index(swc[j].wr_id). Because the credit wr_id is a small value (< 2^32), the decode always yields 0, so scredit_for_qp[] is incremented for the real QP but only ever decremented for QP 0. Once a non-zero QP reaches tx_depth, the credit drain loop

    while (scredit_for_qp[qp_index] == user_param->tx_depth)

can never make progress and the receiver spins forever. The sender's credit window then never advances, no data is transferred, and both sides hang until killed.

This only affects the SEND verb over iWARP (send_rcredit is enabled only for IBV_TRANSPORT_IWARP) and only with more than one QP; with a single QP the decode accidentally matches (slot 0). It reproduces as 0.00 MiB/sec, a "Bad wc status -- 5 -- 5" flush on teardown, and processes that do not exit at the end of --duration, e.g.:

    ib_send_bw --rdma_cm --qp=4 --duration=10 --size=65536 <server>

Encode the credit WQE wr_id with build_wr_id() so it matches the decode side.