### PR TITLE
perftest: fix early exit for run_iter_bi

### DIFF
--- a/src/perftest_resources.c
+++ b/src/perftest_resources.c
@@ -5901,8 +5901,13 @@ int run_iter_bi(struct pingpong_context *ctx,
 					scredit_for_qp[get_wr_id_qp_index(wc_tx[i].wr_id)]--;
 					tot_scredit--;
 				} else  {
-					totccnt += user_param->cq_mod;
-					ctx->ccnt[(int)get_wr_id_qp_index(wc_tx[i].wr_id)] += user_param->cq_mod;
+					int fill = user_param->cq_mod;
+					qp_index = (int)get_wr_id_qp_index(wc_tx[i].wr_id);
+					if (user_param->fill_count && ctx->ccnt[qp_index] + user_param->cq_mod > user_param->iters) {
+							fill = user_param->iters - ctx->ccnt[qp_index];
+					}
+					totccnt += fill;
+					ctx->ccnt[qp_index] += fill;
 
 					if (user_param->noPeak == OFF) {
 


### PR DESCRIPTION
Use right counter for totccnt to prevent early exit which lead to fewer wqe posted on one side. Based on fix from run_iter_bw

former failed case: ib_send_bw -q 16 -s 32 -F -n 1024 -b -d mlx5_0