### PR TITLE
perftest: add system dma-buf memory backend

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ AUTOMAKE_OPTIONS= subdir-objects
 
 noinst_LIBRARIES = libperftest.a
 libperftest_a_SOURCES = src/get_clock.c src/perftest_communication.c src/perftest_negotiation.c src/perftest_parameters.c src/perftest_resources.c src/perftest_counters.c src/host_memory.c src/host_validation.c src/mmap_memory.c src/numa_loader.c
-noinst_HEADERS = src/get_clock.h src/perftest_communication.h src/perftest_negotiation.h src/perftest_parameters.h src/perftest_resources.h src/perftest_counters.h src/memory.h src/host_memory.h src/host_validation.h src/mmap_memory.h src/cuda_memory.h src/rocm_memory.h src/neuron_memory.h src/hl_memory.h src/mlu_memory.h src/cuda_validation.h src/validation_common.h src/dm_memory.h src/musa_memory.h src/numa_loader.h
+noinst_HEADERS = src/get_clock.h src/perftest_communication.h src/perftest_negotiation.h src/perftest_parameters.h src/perftest_resources.h src/perftest_counters.h src/memory.h src/host_memory.h src/host_validation.h src/mmap_memory.h src/cuda_memory.h src/rocm_memory.h src/neuron_memory.h src/hl_memory.h src/mlu_memory.h src/cuda_validation.h src/validation_common.h src/dm_memory.h src/system_dmabuf_memory.h src/musa_memory.h src/numa_loader.h
 
 AM_CFLAGS =
 
@@ -72,6 +72,10 @@ endif
 
 if IB_DM_DMABUF
 libperftest_a_SOURCES += src/dm_memory.c
+endif
+
+if SYSTEM_DMABUF
+libperftest_a_SOURCES += src/system_dmabuf_memory.c
 endif
 
 bin_PROGRAMS = ib_send_bw ib_send_lat ib_write_lat ib_write_bw ib_read_lat ib_read_bw ib_atomic_lat ib_atomic_bw

--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,15 @@ if test "x$HAVE_REG_DMABUF_MR" = "xyes"; then
 	AC_DEFINE([HAVE_REG_DMABUF_MR], [1], [Enable HAVE_REG_DMABUF_MR])
 fi
 
+AC_CHECK_HEADERS([linux/dma-heap.h], [HAVE_DMA_HEAP=yes], [HAVE_DMA_HEAP=no])
+if test "x$HAVE_REG_DMABUF_MR" = "xyes" && test "x$HAVE_DMA_HEAP" = "xyes"; then
+	HAVE_SYSTEM_DMABUF=yes
+	AC_DEFINE([HAVE_SYSTEM_DMABUF], [1], [Enable system DMA-BUF memory])
+else
+	HAVE_SYSTEM_DMABUF=no
+fi
+AM_CONDITIONAL([SYSTEM_DMABUF], [test "x$HAVE_SYSTEM_DMABUF" = "xyes"])
+
 AC_CHECK_LIB([ibverbs], [ibv_dm_export_dmabuf_fd], [HAVE_IB_DM_DMABUF=yes], [HAVE_IB_DM_DMABUF=no])
 AM_CONDITIONAL([IB_DM_DMABUF], [test "x$HAVE_IB_DM_DMABUF" = "xyes"])
 if test "x$HAVE_IB_DM_DMABUF" = "xyes"; then

--- a/man/perftest.1
+++ b/man/perftest.1
@@ -431,6 +431,11 @@ many different options and modes.
  must fit within the device's max_dm_size.
  System support required (rdma-core with ibv_dm_export_dmabuf_fd).
 .TP
+.B --use_sys_dmabuf
+ Use system memory allocated from /dev/dma_heap/system and registered as a
+ DMA-BUF memory region with ibv_reg_dmabuf_mr.
+ System support required (Linux DMA heaps and rdma-core DMA-BUF registration).
+.TP
 .B --use_opencl=<opencl device id>
  Use OpenCl specific device for GPUDirect RDMA testing
  Not relevant for raw_ethernet_fs_rate.

--- a/src/perftest_parameters.c
+++ b/src/perftest_parameters.c
@@ -1,3 +1,4 @@
+#include "system_dmabuf_memory.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -832,6 +833,11 @@ static void usage(const char *argv0, VerbType verb, TestType tst, int connection
 		printf("      --use_cc_unprotected");
 		printf(" Allow unprotected memory allocation for CoCo guests\n");
 
+		if (system_dmabuf_memory_supported()) {
+			printf("      --use_sys_dmabuf");
+			printf(" Use system-memory DMA-heap dma-buf MR (ibv_reg_dmabuf_mr)\n");
+		}
+
 		printf("      --use_hugepages ");
 		printf(" Use Hugepages instead of contig, memalign allocations.\n");
 	}
@@ -1079,6 +1085,7 @@ static void init_perftest_params(struct perftest_parameters *user_param)
 	user_param->opencl_device_id	= 0;
 	user_param->dm_ib_devname	= NULL;
 	user_param->use_ib_dm_dmabuf	= 0;
+	user_param->use_system_dmabuf	= 0;
 	user_param->gpu_touch		= GPU_NO_TOUCH;
 	user_param->mmap_file		= NULL;
 	user_param->mmap_offset		= 0;
@@ -3037,6 +3044,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 	static int opencl_platform_id_flag = 0;
 	static int use_ib_dm_dmabuf_flag = 0;
 	static int use_cc_unprotected_flag = 0;
+	static int use_system_dmabuf_flag = 0;
 	static int gpu_touch_flag = 0;
 	static int disable_pcir_flag = 0;
 	static int mmap_file_flag = 0;
@@ -3242,6 +3250,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 			{ .name = "opencl_platform_id", .has_arg = 1, .flag = &opencl_platform_id_flag, .val = 1},
 			{ .name = "use_ib_dm_dmabuf",	.has_arg = 1, .flag = &use_ib_dm_dmabuf_flag, .val = 1},
 			{ .name = "use_cc_unprotected", .has_arg = 0, .flag = &use_cc_unprotected_flag, .val = 1},
+			{ .name = "use_sys_dmabuf",	.has_arg = 0, .flag = &use_system_dmabuf_flag, .val = 1},
 			{ .name = "gpu_touch",		.has_arg = 1, .flag = &gpu_touch_flag, .val = 1},
 			{ .name = "mmap",		.has_arg = 1, .flag = &mmap_file_flag, .val = 1},
 			{ .name = "mmap-offset",	.has_arg = 1, .flag = &mmap_offset_flag, .val = 1},
@@ -3703,7 +3712,8 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				    (use_mlu_flag && !mlu_memory_supported()) ||
 				    (use_mlu_dmabuf_flag && !mlu_memory_dmabuf_supported()) ||
 				    (use_opencl_flag && !opencl_memory_supported()) ||
-				    (use_ib_dm_dmabuf_flag && !dm_memory_dmabuf_supported())) {
+				    (use_ib_dm_dmabuf_flag && !dm_memory_dmabuf_supported()) ||
+				    (use_system_dmabuf_flag && !system_dmabuf_memory_supported())) {
 					printf(" Unsupported memory type\n");
 					return FAILURE;
 				}
@@ -3714,7 +3724,7 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				/* Memory types are mutually exclucive, make sure we were not already asked to use a different memory type. */
 				if (user_param->memory_type != MEMORY_HOST &&
 				    (mmap_file_flag || use_mlu_flag || use_neuron_flag || use_hl_flag ||
-						use_ib_dm_dmabuf_flag ||
+						use_ib_dm_dmabuf_flag || use_system_dmabuf_flag ||
 					 (use_rocm_flag && user_param->memory_type != MEMORY_ROCM) ||
 					 ((use_musa_flag || use_musa_bus_id_flag) && user_param->memory_type != MEMORY_MUSA) ||
 				     ((use_cuda_flag || use_cuda_bus_id_flag) && user_param->memory_type != MEMORY_CUDA))) {
@@ -3885,6 +3895,12 @@ int parser(struct perftest_parameters *user_param,char *argv[], int argc)
 				if (use_cc_unprotected_flag) {
 					user_param->use_cc_unprotected = 1;
 					use_cc_unprotected_flag = 0;
+				}
+				if (use_system_dmabuf_flag) {
+					user_param->use_system_dmabuf = 1;
+					user_param->memory_type = MEMORY_SYSTEM_DMABUF;
+					user_param->memory_create = system_dmabuf_memory_create;
+					use_system_dmabuf_flag = 0;
 				}
 				if (gpu_touch_flag) {
 					if (!cuda_gpu_touch_supported()) {

--- a/src/perftest_parameters.h
+++ b/src/perftest_parameters.h
@@ -457,7 +457,8 @@ enum memory_type {
 	MEMORY_HL,
 	MEMORY_MLU,
 	MEMORY_OPENCL,
-	MEMORY_DM
+	MEMORY_DM,
+	MEMORY_SYSTEM_DMABUF
 };
 
 enum cuda_mem_type {
@@ -628,6 +629,7 @@ struct perftest_parameters {
 	int                             gpu_touch;
 	char				*dm_ib_devname;
 	int				use_ib_dm_dmabuf;
+	int				use_system_dmabuf;
 	char				*mmap_file;
 	unsigned long			mmap_offset;
 	int				use_cc_unprotected;

--- a/src/system_dmabuf_memory.c
+++ b/src/system_dmabuf_memory.c
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <linux/dma-heap.h>
+#include "system_dmabuf_memory.h"
+#include "perftest_parameters.h"
+
+#define DMA_HEAP_PATH "/dev/dma_heap/system"
+
+struct system_dmabuf_memory_ctx {
+	struct memory_ctx	base;
+	enum verbosity_level	output;
+};
+
+static int system_dmabuf_memory_init(struct memory_ctx *ctx)
+{
+	return SUCCESS;
+}
+
+static int system_dmabuf_memory_destroy(struct memory_ctx *ctx)
+{
+	struct system_dmabuf_memory_ctx *sdc =
+		container_of(ctx, struct system_dmabuf_memory_ctx, base);
+
+	free(sdc);
+	return SUCCESS;
+}
+
+static int system_dmabuf_memory_allocate_buffer(struct memory_ctx *ctx,
+						int alignment, uint64_t size,
+						int *dmabuf_fd,
+						uint64_t *dmabuf_offset,
+						void **addr, bool *can_init)
+{
+	struct system_dmabuf_memory_ctx *sdc =
+		container_of(ctx, struct system_dmabuf_memory_ctx, base);
+	struct dma_heap_allocation_data alloc = {
+		.len      = size,
+		.fd_flags = O_RDWR | O_CLOEXEC,
+	};
+	int heap_fd;
+	void *mmap_addr;
+
+	heap_fd = open(DMA_HEAP_PATH, O_RDONLY | O_CLOEXEC);
+	if (heap_fd < 0) {
+		fprintf(stderr, "Failed to open %s: %s\n",
+			DMA_HEAP_PATH, strerror(errno));
+		return FAILURE;
+	}
+
+	if (ioctl(heap_fd, DMA_HEAP_IOCTL_ALLOC, &alloc) < 0) {
+		int saved_errno = errno;
+
+		close(heap_fd);
+		fprintf(stderr, "DMA heap alloc (%lu bytes) failed: %s\n",
+			(unsigned long)size, strerror(saved_errno));
+		return FAILURE;
+	}
+
+	/*
+	 * Do not retain the dma heap char device fd because CRIU can't
+	 * checkpoint it. DMA_HEAP_IOCTL_ALLOC installs an independent dma buf
+	 * fd in alloc.fd so closing the allocator fd can't release the buffer
+	 */
+	close(heap_fd);
+
+	mmap_addr = mmap(NULL, size, PROT_READ | PROT_WRITE,
+			 MAP_SHARED, alloc.fd, 0);
+	if (mmap_addr == MAP_FAILED) {
+		fprintf(stderr, "mmap of dma-buf failed: %s\n", strerror(errno));
+		close(alloc.fd);
+		return FAILURE;
+	}
+
+	*dmabuf_fd = alloc.fd;
+	*dmabuf_offset = 0;
+	*addr = mmap_addr;
+	*can_init = true;
+
+	if (sdc->output == FULL_VERBOSITY)
+		printf("System dma-buf: %lu bytes, fd=%d addr=%p\n",
+		       (unsigned long)size, alloc.fd, mmap_addr);
+	return SUCCESS;
+}
+
+static int system_dmabuf_memory_free_buffer(struct memory_ctx *ctx,
+					    int dmabuf_fd, void *addr,
+					    uint64_t size)
+{
+	if (munmap(addr, size)) {
+		fprintf(stderr, "munmap of dma-buf failed: %s\n", strerror(errno));
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+
+bool system_dmabuf_memory_supported()
+{
+	return true;
+}
+
+struct memory_ctx *system_dmabuf_memory_create(struct perftest_parameters *params)
+{
+	struct system_dmabuf_memory_ctx *ctx;
+
+	ALLOCATE(ctx, struct system_dmabuf_memory_ctx, 1);
+	ctx->base.init = system_dmabuf_memory_init;
+	ctx->base.destroy = system_dmabuf_memory_destroy;
+	ctx->base.allocate_buffer = system_dmabuf_memory_allocate_buffer;
+	ctx->base.free_buffer = system_dmabuf_memory_free_buffer;
+	ctx->base.copy_host_to_buffer = memcpy;
+	ctx->base.copy_buffer_to_host = memcpy;
+	ctx->base.copy_buffer_to_buffer = memcpy;
+	ctx->output = params->output;
+
+	return &ctx->base;
+}

--- a/src/system_dmabuf_memory.h
+++ b/src/system_dmabuf_memory.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+
+#ifndef SYSTEM_DMABUF_MEMORY_H
+#define SYSTEM_DMABUF_MEMORY_H
+
+#include "memory.h"
+#include "config.h"
+
+struct perftest_parameters;
+
+#ifdef HAVE_SYSTEM_DMABUF
+bool system_dmabuf_memory_supported();
+struct memory_ctx *system_dmabuf_memory_create(struct perftest_parameters *params);
+#else
+static inline bool system_dmabuf_memory_supported()
+{
+	return false;
+}
+
+static inline struct memory_ctx *system_dmabuf_memory_create(struct perftest_parameters *params)
+{
+	return NULL;
+}
+#endif
+
+#endif /* SYSTEM_DMABUF_MEMORY_H */


### PR DESCRIPTION
Add a backend that uses system memory allocated from /dev/dma_heap/system and is registered as a dma-buf memory region with ibv_reg_dmabuf_mr. It is helpful when testing dma-buf paths without other exporters of dma-bufs. Open the dma heap device separately for each allocation and close it immediately after DMA_HEAP_IOCTL_ALLOC. This avoids retaining an unknown char device fd across CRIU checkpoint while remaining safe because the ioctl returns an independent dma buf fd that owns the allocated buffer. Support is automatically detected by the configure script. Runtime use requires accessible /dev/dma_heap/system device.

The new command-line argument is: --use_sys_dmabuf